### PR TITLE
fix: disable automatic sign-ups in email OTP flow

### DIFF
--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -41,6 +41,7 @@ export const auth = betterAuth({
     emailOTP({
       otpLength: 6,
       expiresIn: 10 * 60 * 1000, // 10 minutes in milliseconds
+      disableSignUp: true,
       async sendVerificationOTP({ email, otp, type }) {
         await transporter.sendMail({
           from: process.env.EMAIL_FROM,


### PR DESCRIPTION
Adds disableSignUp: true to the emailOTP plugin config to prevent better-auth from auto-creating Volunteer records for unknown emails during OTP sign-in.