### PR TITLE
feat: add Google OAuth login via BA

### DIFF
--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { FormSubmitEvent } from '@nuxt/ui'
+import { authClient } from '#server/utils/auth-client'
 import {
   requestOtpFields,
   requestOtpSchema,
@@ -13,6 +14,17 @@ const isLoading = ref(false)
 const errorMessage = ref<string | null>(null)
 const step = ref<'request' | 'verify'>('request')
 const pendingEmail = ref<string>('')
+
+async function signInWithGoogle() {
+  isLoading.value = true
+  errorMessage.value = null
+  const { error } = await authClient.signIn.social({ provider: 'google', callbackURL: '/' })
+  if (error) {
+    errorMessage.value = error.message ?? 'Failed to sign in with Google'
+    isLoading.value = false
+  }
+  // On success the redirect plugin navigates away — don't reset isLoading
+}
 
 async function onRequestOtp(event: FormSubmitEvent<RequestOtpSchema>) {
   isLoading.value = true
@@ -91,6 +103,21 @@ function goBack() {
           icon="i-lucide-info"
           :title="errorMessage"
         />
+      </template>
+      <template #providers>
+        <UButton
+          block
+          color="neutral"
+          variant="outline"
+          icon="i-simple-icons-google"
+          :loading="isLoading"
+          @click="signInWithGoogle"
+        >
+          Continue with Google
+        </UButton>
+      </template>
+      <template #separator>
+        <USeparator label="or" />
       </template>
       <template #footer>
         By signing in, you agree to our

--- a/server/api/auth/[...better-auth].ts
+++ b/server/api/auth/[...better-auth].ts
@@ -1,0 +1,6 @@
+import { auth } from '#server/utils/auth'
+import { toWebRequest } from 'h3'
+
+export default defineEventHandler((event) => {
+  return auth.handler(toWebRequest(event))
+})

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -21,6 +21,13 @@ const transporter = nodemailer.createTransport({
 
 
 export const auth = betterAuth({
+  socialProviders: {
+    google: {
+      clientId: process.env.OAUTH_CLIENT_ID as string,
+      clientSecret: process.env.OAUTH_CLIENT_SECRET as string,
+      disableSignUp: true,
+    },
+  },
   hooks: {
     after: createAuthMiddleware(async (ctx) => {
       if (ctx.path === '/get-session') {


### PR DESCRIPTION
- Adds Google as a social login provider via better-auth's `socialProviders` config
- Adds a catch-all route `[...better-auth].ts` to handle OAuth flow paths (`/sign-in/social`, `/callback/google`, etc.)
- Adds a "Continue with Google" button to the login page above the email/OTP form