### PR TITLE
feat: multi-step sign-up with OTP email verification

### DIFF
--- a/app/middleware/auth.ts
+++ b/app/middleware/auth.ts
@@ -1,5 +1,5 @@
 export default defineNuxtRouteMiddleware(async (to) => {
-  const publicRoutes = ['/auth/login', '/auth/sign-up']
+  const publicRoutes = ['/auth/login', '/auth/sign-up', '/auth/sign-up-verify']
   if (publicRoutes.includes(to.path)) return
 
   try {

--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -14,6 +14,28 @@ const errorMessage = ref<string | null>(null)
 const step = ref<'request' | 'verify'>('request')
 const pendingEmail = ref<string>('')
 
+const resendCooldown = ref(0)
+const isResending = ref(false)
+const resendError = ref<string | null>(null)
+let cooldownTimer: ReturnType<typeof setInterval> | null = null
+
+function startCooldown() {
+  resendCooldown.value = 30
+  if (cooldownTimer) clearInterval(cooldownTimer)
+  cooldownTimer = setInterval(() => {
+    if (resendCooldown.value > 0) {
+      resendCooldown.value--
+    } else {
+      clearInterval(cooldownTimer!)
+      cooldownTimer = null
+    }
+  }, 1000)
+}
+
+onUnmounted(() => {
+  if (cooldownTimer) clearInterval(cooldownTimer)
+})
+
 async function onRequestOtp(event: FormSubmitEvent<RequestOtpSchema>) {
   isLoading.value = true
   errorMessage.value = null
@@ -25,6 +47,7 @@ async function onRequestOtp(event: FormSubmitEvent<RequestOtpSchema>) {
     })
     pendingEmail.value = event.data.email
     step.value = 'verify'
+    startCooldown()
   }
   catch (error: unknown) {
     errorMessage.value = (error as { message: string }).message
@@ -57,9 +80,28 @@ async function onVerifyOtp(event: FormSubmitEvent<VerifyOtpSchema>) {
   }
 }
 
+async function resendOtp() {
+  if (!pendingEmail.value || resendCooldown.value > 0) return
+  isResending.value = true
+  resendError.value = null
+  try {
+    await $fetch('/api/auth/request-otp', {
+      method: 'POST',
+      body: { email: pendingEmail.value },
+    })
+    startCooldown()
+  } catch (err: unknown) {
+    resendError.value = (err as { message: string }).message
+  } finally {
+    isResending.value = false
+  }
+}
+
 function goBack() {
   step.value = 'request'
   errorMessage.value = null
+  if (cooldownTimer) clearInterval(cooldownTimer)
+  resendCooldown.value = 0
 }
 </script>
 
@@ -129,6 +171,30 @@ function goBack() {
           icon="i-lucide-info"
           :title="errorMessage"
         />
+      </template>
+      <template #footer>
+        <div class="flex flex-col items-center gap-2 w-full">
+          <div class="text-sm">
+            <span v-if="resendCooldown > 0" class="text-muted">Resend code in {{ resendCooldown }}s</span>
+            <UButton
+              v-else
+              variant="link"
+              size="sm"
+              :loading="isResending"
+              class="p-0"
+              @click="resendOtp"
+            >
+              Resend code
+            </UButton>
+          </div>
+          <UAlert
+            v-if="resendError"
+            color="error"
+            icon="i-lucide-info"
+            :title="resendError"
+            class="w-full"
+          />
+        </div>
       </template>
     </UAuthForm>
   </div>

--- a/app/pages/auth/sign-up-verify.vue
+++ b/app/pages/auth/sign-up-verify.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import type { FormSubmitEvent } from '@nuxt/ui'
+import { verifyOtpFields, verifyOtpSchema, type VerifyOtpSchema } from '~/types/auth/login.type'
+
+const errorMessage = ref<string | null>(null)
+const isLoading = ref(false)
+const pendingSignUp = ref<Record<string, unknown> | null>(null)
+
+const resendCooldown = ref(0)
+const isResending = ref(false)
+const resendError = ref<string | null>(null)
+let cooldownTimer: ReturnType<typeof setInterval> | null = null
+
+function startCooldown() {
+  resendCooldown.value = 30
+  if (cooldownTimer) clearInterval(cooldownTimer)
+  cooldownTimer = setInterval(() => {
+    if (resendCooldown.value > 0) {
+      resendCooldown.value--
+    } else {
+      clearInterval(cooldownTimer!)
+      cooldownTimer = null
+    }
+  }, 1000)
+}
+
+onMounted(() => {
+  const stored = sessionStorage.getItem('pendingSignUp')
+  if (!stored) {
+    navigateTo('/auth/sign-up')
+    return
+  }
+  pendingSignUp.value = JSON.parse(stored)
+  startCooldown()
+})
+
+onUnmounted(() => {
+  if (cooldownTimer) clearInterval(cooldownTimer)
+})
+
+async function resendOtp() {
+  if (!pendingSignUp.value?.email || resendCooldown.value > 0) return
+  isResending.value = true
+  resendError.value = null
+  try {
+    await $fetch('/api/auth/request-otp', {
+      method: 'POST',
+      body: { email: pendingSignUp.value.email },
+    })
+    startCooldown()
+  } catch (err: unknown) {
+    resendError.value = (err as { message: string }).message
+  } finally {
+    isResending.value = false
+  }
+}
+
+async function onVerify(event: FormSubmitEvent<VerifyOtpSchema>) {
+  if (!pendingSignUp.value) return
+  isLoading.value = true
+  errorMessage.value = null
+
+  try {
+    await $fetch('/api/auth/sign-up-verify', {
+      method: 'POST',
+      body: {
+        otp: event.data.otp,
+        ...pendingSignUp.value,
+      },
+    })
+    sessionStorage.removeItem('pendingSignUp')
+    await nextTick()
+    await navigateTo('/volunteer/')
+  }
+  catch (error: unknown) {
+    console.log(error)
+    errorMessage.value = (error as { message: string }).message
+  }
+  finally {
+    isLoading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-col items-center justify-center p-8 min-h-screen">
+    <UAuthForm
+      class="w-full max-w-md"
+      :schema="verifyOtpSchema"
+      :fields="verifyOtpFields"
+      title="Check your email"
+      icon="i-lucide-shield-check"
+      :submit="{ label: 'Verify & create account', block: true, color: 'neutral' }"
+      @submit="onVerify"
+    >
+      <template #description>
+        We sent a 6-digit code to <strong>{{ (pendingSignUp as any)?.email }}</strong>.
+        <ULink
+          to="/auth/sign-up"
+          class="text-primary font-medium"
+        >
+          Wrong email?
+        </ULink>
+      </template>
+      <template #validation>
+        <UAlert
+          v-if="errorMessage"
+          color="error"
+          icon="i-lucide-info"
+          :title="errorMessage"
+        />
+      </template>
+      <template #footer>
+        <div class="flex flex-col items-center gap-2 w-full">
+          <div class="text-sm">
+            <span v-if="resendCooldown > 0" class="text-muted">Resend code in {{ resendCooldown }}s</span>
+            <UButton
+              v-else
+              variant="link"
+              size="sm"
+              :loading="isResending"
+              class="p-0"
+              @click="resendOtp"
+            >
+              Resend code
+            </UButton>
+          </div>
+          <UAlert
+            v-if="resendError"
+            color="error"
+            icon="i-lucide-info"
+            :title="resendError"
+            class="w-full"
+          />
+          <span>By signing up, you agree to our <ULink
+            to="#"
+            class="text-primary font-medium"
+          >Terms of Service</ULink>.</span>
+        </div>
+      </template>
+    </UAuthForm>
+  </div>
+</template>

--- a/app/pages/auth/sign-up.vue
+++ b/app/pages/auth/sign-up.vue
@@ -10,22 +10,23 @@ const isLoading = ref(false)
 
 async function onSubmit(payload: FormSubmitEvent<SignUpSchema>) {
   isLoading.value = true
+  errorMessage.value = null
   console.log(payload.data)
   try {
-    await $fetch('/api/auth/sign-up', {
+    await $fetch('/api/auth/request-otp', {
       method: 'POST',
-      body: {
-        name: payload.data.name,
-        email: payload.data.email,
-        phone: payload.data.phone,
-        languages: payload.data.languages,
-        gender: payload.data.gender,
-        ethinicity: payload.data.ethinicity,
-        availability: payload.data.availability,
-      },
+      body: { email: payload.data.email },
     })
-    await nextTick()
-    await navigateTo('/volunteer/')
+    sessionStorage.setItem('pendingSignUp', JSON.stringify({
+      name: payload.data.name,
+      email: payload.data.email,
+      phone: payload.data.phone,
+      languages: payload.data.languages,
+      gender: payload.data.gender,
+      ethinicity: payload.data.ethinicity,
+      availability: payload.data.availability,
+    }))
+    await navigateTo('/auth/sign-up-verify')
   }
   catch (error: unknown) {
     console.log(error)

--- a/app/types/auth/sign-up.type.ts
+++ b/app/types/auth/sign-up.type.ts
@@ -5,7 +5,6 @@ import type { InputMenuItem, AuthFormField } from '@nuxt/ui'
 export const signUpSchema = z.object({
   name: z.string().optional(),
   email: z.email('Invalid email'),
-  password: z.string().min(8, 'Must be at least 8 characters'),
   phone: z.preprocess(val => {
     if (typeof val !== 'string' || !val) return val
     const digits = val.replace(/\D/g, '')

--- a/server/api/auth/request-otp.post.ts
+++ b/server/api/auth/request-otp.post.ts
@@ -1,42 +1,39 @@
-import { auth } from '#server/utils/auth'
-import type { H3Event } from 'h3'
-import { appendHeader, setHeader } from 'h3'
-
-const forwardAuthHeaders = (event: H3Event, headers?: Headers) => {
-    if (!headers) return
-    headers.forEach((value, key) => {
-        if (key.toLowerCase() === 'set-cookie') {
-            appendHeader(event, 'set-cookie', value)
-        }
-        else {
-            setHeader(event, key, value)
-        }
-    })
-}
+import { transporter } from '#server/utils/auth'
+import prisma from '#server/utils/prisma'
+import { randomInt, randomBytes } from 'crypto'
 
 export default defineEventHandler(async (event) => {
-    try {
-        const { email } = await readBody(event)
-        const { response, headers } = await auth.api.sendVerificationOTP({
-            body: {
-                email,
-                type: 'sign-in',
-            },
-            headers: event.headers,
-            returnHeaders: true,
-        })
+  try {
+    const { email } = await readBody(event)
 
-        forwardAuthHeaders(event, headers)
+    const otp = randomInt(100000, 1000000).toString()
+    const id = randomBytes(16).toString('hex')
+    const expiresAt = new Date(Date.now() + 10 * 60 * 1000)
 
-        return { success: true }
-    }
-    catch (error: unknown) {
-        console.log(error)
-        throw createError({
-            statusCode: (error as { statusCode: number }).statusCode ?? 500,
-            statusMessage:
-                (error as { body: { message: string } }).body?.message
-                ?? 'An unexpected error occurred',
-        })
-    }
+    await prisma.verification.create({
+      data: {
+        id,
+        identifier: `sign-in-otp-${email}`,
+        value: `${otp}:0`,
+        expiresAt,
+      },
+    })
+
+    await transporter.sendMail({
+      from: process.env.EMAIL_FROM,
+      to: email,
+      subject: 'OTP for Abide Connect',
+      html: `Your OTP is: ${otp}`,
+    })
+
+    return { success: true }
+  }
+  catch (error: unknown) {
+    console.error('[request-otp error]', error)
+    throw createError({
+      statusCode: (error as { statusCode?: number }).statusCode ?? 500,
+      statusMessage:
+        (error as { message?: string }).message ?? 'An unexpected error occurred',
+    })
+  }
 })

--- a/server/api/auth/sign-up-verify.post.ts
+++ b/server/api/auth/sign-up-verify.post.ts
@@ -1,0 +1,106 @@
+import { auth } from '#server/utils/auth'
+import prisma from '#server/utils/prisma'
+import type { Language, Availability } from '#server/utils/generated/prisma/client'
+import { Prisma } from '#server/utils/generated/prisma/client'
+import type { H3Event } from 'h3'
+import { appendHeader, setHeader } from 'h3'
+
+const forwardAuthHeaders = (event: H3Event, headers?: Headers) => {
+  if (!headers) return
+  headers.forEach((value, key) => {
+    if (key.toLowerCase() === 'set-cookie') {
+      appendHeader(event, 'set-cookie', value)
+    }
+    else {
+      setHeader(event, key, value)
+    }
+  })
+}
+
+export default defineEventHandler(async (event) => {
+  try {
+    const {
+      otp,
+      name,
+      email,
+      phone,
+      languages = [],
+      gender,
+      ethinicity,
+      availability = [],
+    } = await readBody(event)
+
+    // Validate OTP exists and hasn't expired before creating the account.
+    // Better Auth stores with identifier "sign-in-otp-<email>" and value "<otp>:<attempts>".
+    // Multiple stale records can exist for the same email, so match on the value prefix.
+    const verification = await prisma.verification.findFirst({
+      where: {
+        identifier: `sign-in-otp-${email}`,
+        value: { startsWith: otp },
+      },
+      orderBy: { expiresAt: 'desc' },
+    })
+
+    if (!verification || new Date() > verification.expiresAt) {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid or expired code' })
+    }
+
+    const selectedLanguages = languages as Language[]
+    const selectedAvailability = availability as Availability[]
+
+    await prisma.$transaction(async (tx) => {
+      const createdUser = await tx.user.create({
+        data: {
+          name: name as string | undefined,
+          contactEmail: email as string,
+          phone: phone as string | undefined,
+        },
+      })
+
+      await tx.volunteer.create({
+        data: {
+          email: email as string,
+          name: name as string | undefined,
+          phone: phone as string | undefined,
+          gender: gender.id,
+          ethinicity: ethinicity.id,
+          userId: createdUser.id,
+          languages: {
+            create: selectedLanguages.map(language => ({ language })),
+          },
+          availabilities: {
+            create: selectedAvailability.map(time => ({ availability: time })),
+          },
+        },
+      })
+    })
+
+    // OTP still in Verification table — signInEmailOTP validates it and creates
+    // a session now that the Volunteer record exists, then consumes the OTP.
+    const { response, headers } = await auth.api.signInEmailOTP({
+      body: { email, otp },
+      headers: event.headers,
+      returnHeaders: true,
+    })
+
+    forwardAuthHeaders(event, headers)
+
+    return { success: true, ...response }
+  }
+  catch (error: unknown) {
+    console.error('[sign-up-verify error]', error)
+
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      throw createError({ statusCode: 409, statusMessage: 'An account with this email already exists' })
+    }
+
+    const statusCode = (error as { statusCode?: number }).statusCode ?? 500
+    const statusMessage =
+      (error as { body?: { message?: string } }).body?.message
+      ?? (error as { statusMessage?: string }).statusMessage
+      ?? (error as { message?: string }).message
+      ?? 'An unexpected error occurred'
+
+    throw createError({ statusCode, statusMessage })
+  }
+})

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -9,7 +9,7 @@ console.log('[nodemailer] EMAIL_HOST:', process.env.EMAIL_HOST)
 console.log('[nodemailer] EMAIL_USER:', process.env.EMAIL_USER)
 console.log('[nodemailer] EMAIL_PASS length:', process.env.EMAIL_PASS?.length)
 
-const transporter = nodemailer.createTransport({
+export const transporter = nodemailer.createTransport({
   host: process.env.EMAIL_HOST,
   port: 587,
   secure: false, // use STARTTLS (upgrade connection to TLS after connecting)
@@ -40,15 +40,20 @@ export const auth = betterAuth({
   plugins: [
     emailOTP({
       otpLength: 6,
-      expiresIn: 10 * 60 * 1000, // 10 minutes in milliseconds
+      expiresIn: 10 * 60, // 10 minutes in seconds
       disableSignUp: true,
       async sendVerificationOTP({ email, otp, type }) {
-        await transporter.sendMail({
-          from: process.env.EMAIL_FROM,
-          to: email,
-          subject: 'OTP for Abide Connect',
-          html: `Your OTP is: ${otp}`,
-        })
+        try {
+          await transporter.sendMail({
+            from: process.env.EMAIL_FROM,
+            to: email,
+            subject: 'OTP for Abide Connect',
+            html: `Your OTP is: ${otp}`,
+          })
+        } catch (err) {
+          console.error('[sendVerificationOTP] Failed to send email to', email, err)
+          throw err
+        }
       },
     }),
   ],


### PR DESCRIPTION
## Summary
- Adds a new `/auth/sign-up-verify` page that accepts a 6-digit OTP before finalizing account creation, turning sign-up into a two-step email-verified flow
- Replaces the direct Better Auth `sendVerificationOTP` call in `request-otp.post.ts` with a custom implementation using Node `crypto`, storing the OTP in the `Verification` table directly
- Adds `sign-up-verify.post.ts` which validates the OTP, creates the `User` + `Volunteer` records in a transaction, then calls `signInEmailOTP` to issue a session — so the account is only created after the email address is confirmed
- Adds a 30-second resend-code cooldown (with timer cleanup) to both the login and sign-up-verify pages
- Fixes `expiresIn` unit in Better Auth `emailOTP` config (was milliseconds, must be seconds), exports `transporter` from `server/utils/auth.ts`, and adds error handling around `sendVerificationOTP`
- Removes the `password` field from the sign-up schema and updates the auth middleware to whitelist `/auth/sign-up-verify`

## Test plan
- [ ] Complete sign-up flow: fill out form → receive OTP email → enter code → land on `/volunteer/`
- [ ] Verify that navigating directly to `/auth/sign-up-verify` without going through sign-up redirects back to `/auth/sign-up`
- [ ] Verify invalid/expired OTP returns a 400 error with "Invalid or expired code"
- [ ] Verify duplicate email returns a 409 error
- [ ] Verify resend button is disabled for 30 s after each send, then re-enables
- [ ] Verify login page resend-code flow still works correctly