### PR TITLE
feat: add Google OAuth sign-in via better-auth

### DIFF
--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -100,6 +100,14 @@ function goBack() {
         >
           Terms of Service
         </ULink>.
+        <div class="mt-4 text-center">
+          <ULink
+            to="/auth/staff-login"
+            class="text-muted font-medium text-sm"
+          >
+            Staff Login
+          </ULink>
+        </div>
       </template>
     </UAuthForm>
 

--- a/app/pages/auth/staff-login.vue
+++ b/app/pages/auth/staff-login.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { authClient } from '#server/utils/auth-client'
+
+const isLoading = ref(true)
+const errorMessage = ref<string | null>(null)
+
+async function signInWithGoogle() {
+  isLoading.value = true
+  errorMessage.value = null
+  const { data, error } = await authClient.signIn.social({
+    provider: 'google',
+    callbackURL: window.location.origin + '/',
+    disableRedirect: true,
+  })
+  if (error) {
+    errorMessage.value = error.message ?? 'Failed to sign in with Google'
+    isLoading.value = false
+    return
+  }
+  if (data?.url) {
+    await navigateTo(data.url, { external: true })
+  }
+}
+
+onMounted(signInWithGoogle)
+</script>
+
+<template>
+  <div class="flex flex-col items-center justify-center p-8 min-h-screen">
+    <div
+      v-if="!errorMessage"
+      class="flex flex-col items-center gap-3"
+    >
+      <UIcon
+        name="i-lucide-loader-circle"
+        class="size-8 text-primary animate-spin"
+      />
+      <p class="text-muted text-sm">
+        Redirecting to Google…
+      </p>
+    </div>
+    <UCard
+      v-else
+      class="w-full max-w-md"
+    >
+      <div class="flex flex-col items-center gap-6 py-4">
+        <UIcon
+          name="i-lucide-shield"
+          class="size-10 text-primary"
+        />
+        <div class="text-center">
+          <h1 class="text-2xl font-bold">
+            Staff Login
+          </h1>
+          <p class="text-muted mt-1 text-sm">
+            Sign in with your organization Google account.
+          </p>
+        </div>
+        <UAlert
+          color="error"
+          icon="i-lucide-info"
+          :title="errorMessage"
+          class="w-full"
+        />
+        <UButton
+          block
+          color="neutral"
+          variant="outline"
+          icon="i-simple-icons-google"
+          :loading="isLoading"
+          @click="signInWithGoogle"
+        >
+          Continue with Google
+        </UButton>
+        <ULink
+          to="/auth/login"
+          class="text-muted font-medium text-sm"
+        >
+          Back to volunteer login
+        </ULink>
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/server/api/auth/[...all].ts
+++ b/server/api/auth/[...all].ts
@@ -1,0 +1,6 @@
+import { auth } from '#server/utils/auth'
+import { toWebRequest } from 'h3'
+
+export default defineEventHandler((event) => {
+  return auth.handler(toWebRequest(event))
+})

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -51,6 +51,7 @@ export const auth = betterAuth({
     emailOTP({
       otpLength: 6,
       expiresIn: 10 * 60 * 1000, // 10 minutes in milliseconds
+      disableSignUp: true,
       async sendVerificationOTP({ email, otp, type }) {
         await transporter.sendMail({
           from: process.env.EMAIL_FROM,

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -21,6 +21,12 @@ const transporter = nodemailer.createTransport({
 
 
 export const auth = betterAuth({
+  socialProviders: {
+    google: {
+      clientId: process.env.OAUTH_CLIENT_ID as string,
+      clientSecret: process.env.OAUTH_CLIENT_SECRET as string,
+    },
+  },
   hooks: {
     after: createAuthMiddleware(async (ctx) => {
       if (ctx.path === '/get-session') {
@@ -36,12 +42,15 @@ export const auth = betterAuth({
   }),
   user: {
     modelName: 'Volunteer',
+    fields: {
+      // better-auth's user schema uses `image`; our Volunteer column is `imageURL`
+      image: 'imageURL',
+    },
   },
   plugins: [
     emailOTP({
       otpLength: 6,
       expiresIn: 10 * 60 * 1000, // 10 minutes in milliseconds
-      disableSignUp: true,
       async sendVerificationOTP({ email, otp, type }) {
         await transporter.sendMail({
           from: process.env.EMAIL_FROM,


### PR DESCRIPTION
## Summary
Adds Google OAuth sign-in on top of the existing email-OTP auth, targeting `summer26`.

- Configure the Google social provider in better-auth (`server/utils/auth.ts`)
- Map better-auth's `image` user field to the `Volunteer.imageURL` column
- Add the better-auth catch-all route handler at `server/api/auth/[...all].ts` so OAuth callbacks are handled
- Add a staff login page (`app/pages/auth/staff-login.vue`) and link to it from the main login page

## Notes
- Requires `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` env vars for the Google provider.
- The existing custom OTP endpoints (`login.post.ts`, `verify-otp.post.ts`, etc.) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
