### PR TITLE
feat: sync events to shared Google Calendar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,12 @@ EMAIL_PORT=          # Usually 587 (STARTTLS) or 465 (SSL)
 EMAIL_USER=          # Email address used as the sender
 EMAIL_PASS=          # Password or app-specific password for the sender account
 EMAIL_FROM=          # "From" address shown in the inbox (can be same as EMAIL_USER)
+
+# Google OAuth (sign-in + calendar sync). Create credentials in Google Cloud
+# Console and enable the Google Calendar API.
+OAUTH_CLIENT_ID=     # Google OAuth 2.0 client ID
+OAUTH_CLIENT_SECRET= # Google OAuth 2.0 client secret
+# ID of the shared Google Calendar events are pushed to (its email-style address,
+# e.g. abc123@group.calendar.google.com). Volunteers who create events must have
+# write access to this calendar for the push to succeed.
+GOOGLE_CALENDAR_ID=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Abide Connect is a Nuxt 4 PWA for Abide Women's Health Services: volunteer/donor engagement, event management, mobile clinic locator, and an admin dashboard. Package manager is **pnpm** (required — `.npmrc`/`pnpm-workspace.yaml` assume it; don't use npm/yarn).
+
+## Commands
+
+```bash
+pnpm install              # install deps (runs `nuxt prepare` via postinstall)
+pnpm dev                  # dev server at http://localhost:3000
+pnpm build                # production build
+pnpm generate             # static generation
+pnpm preview              # preview a production build
+pnpm lint                 # eslint .
+pnpm lint:fix              # eslint . --fix
+pnpm db:generate          # prisma generate (regenerate client after schema changes)
+```
+
+There is no test suite configured in this repo currently.
+
+### Database (Prisma + SQLite)
+
+Schema lives across multiple files under `prisma/schema/` (not a single `schema.prisma`), configured via `prisma.config.ts`. The generated client is emitted to `server/utils/generated/prisma` (not `node_modules`), imported in `server/utils/prisma.ts` via a `PrismaClient` + `@prisma/adapter-better-sqlite3` singleton.
+
+```bash
+pnpm prisma generate           # regenerate client after editing prisma/schema/*.prisma
+pnpm prisma migrate dev        # create/apply a migration
+pnpm prisma db seed            # seed from prisma/seed/*.json via server/utils/seed.ts
+pnpm prisma migrate reset      # reset DB, then re-seed
+```
+
+After changing any file in `prisma/schema/`, always run `pnpm prisma generate` (and a migration if the change is structural) — the app imports types directly from the generated output.
+
+### Environment
+
+Copy `.env.example` to `.env` before running anything. Required vars: `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `DATABASE_URL`, `IMAGE_STORAGE_PATH`/`IMAGE_URL_PATH` (local image storage), `EMAIL_HOST`/`EMAIL_PORT`/`EMAIL_USER`/`EMAIL_PASS`/`EMAIL_FROM` (SMTP via nodemailer, used for OTP emails). Google OAuth uses `OAUTH_CLIENT_ID`/`OAUTH_CLIENT_SECRET` (see `server/utils/auth.ts`). `GOOGLE_CALENDAR_ID` is the shared calendar events are synced to (see below).
+
+### Google Calendar sync
+
+When an event is created/updated/deleted, `server/utils/googleCalendar.ts` mirrors it to a single shared Google Calendar (`GOOGLE_CALENDAR_ID`). Writes use the acting volunteer's Google OAuth token — obtained via `auth.api.getAccessToken({ body: { providerId: 'google', userId } })`, which refreshes using the stored refresh token — so the Google provider requests the `calendar.events` scope with `accessType: 'offline'` + `prompt: 'consent'` (in `auth.ts`). The Google event id is stored on `Event.calendarEventId` (and its link on `Event.calendarURL`) for later update/delete. Sync is **best-effort**: if the acting volunteer signed in with email OTP (no Google token) or the Calendar API fails, the DB operation still succeeds and the calendar is simply not updated.
+
+## Architecture
+
+This is a Nuxt 4 app, so the app source root is `app/` (pages, components, layouts, middleware, lib, types), while `server/` holds Nitro server routes/middleware/utils and is a separate root — cross-referencing it from `app/` code goes through the `#server` path alias (e.g. `import { auth } from '#server/utils/auth'`), not a relative path.
+
+### Auth (better-auth)
+
+- `server/utils/auth.ts` configures `better-auth` with the Prisma adapter, pointed at a custom `Volunteer` model (via `user: { modelName: 'Volunteer', fields: { image: 'imageURL' } }`) instead of the default `User` model — the schema's own `User` model (`prisma/schema/user.prisma`) is a separate concept representing RSVP guests/contacts, not the authenticated principal.
+- Two auth methods are wired: Google OAuth (`socialProviders.google`) and email OTP (`emailOTP` plugin, `disableSignUp: true` — sign-up must happen through the app's own sign-up flow, not automatically on first OTP request). OTP emails are sent via a nodemailer SMTP transport.
+- `server/api/auth/[...all].ts` mounts the better-auth handler for all `/api/auth/*` routes.
+- `server/middleware/authenticated.ts` runs on every request, attaches `event.context.session`, and hard-redirects unauthenticated requests to `/auth/login` for any path under `/volunteer` or `/api/volunteer`.
+- `app/middleware/auth.ts` is the client-side route guard: it calls `/api/auth/get-session` and redirects to `/auth/login` unless the route is in its `publicRoutes` allowlist. Add new public pages to that list explicitly.
+- `server/utils/auth-client.ts` exports the `better-auth/vue` client (`authClient`) for use in components/pages.
+
+### Data model (`prisma/schema/*.prisma`)
+
+Split by domain: `user.prisma` (RSVP-only guest `User`), `volunteer.prisma` (the authenticated `Volunteer` plus availability/certification/hour-log/language join tables), `event.prisma` (`Event`, `Event_Asset`, `RSVP`, `GuestRSVP`), `donation.prisma`, `location.prisma`, `mobileClinic.prisma`, `notification.prisma`. `schema.prisma` itself only defines the generator/datasource plus better-auth's own `Session`/`Account`/`Verification` models — those FK to `Volunteer`, not `User`, per the auth config above.
+
+Note the two distinct "attendee" concepts: `User` (guest, RSVP-capable, no login) vs `Volunteer` (authenticated, can log hours/certifications). A `Volunteer` can optionally link to a `User` record (`Volunteer.userId`).
+
+### Server API (`server/api/`)
+
+File-based Nitro routes, one file per HTTP method (e.g. `events/index.get.ts` + `events/index.post.ts`, `events/[id]/index.patch.ts`). Admin-only routes live under `server/api/admin/`; there's no separate role-middleware yet, so authorization checks happen inline per-handler where present — check `event.context.session` for the current principal. Server code imports Prisma via `#server/utils/prisma` (default export).
+
+### Frontend structure (`app/`)
+
+- `pages/` mirrors routes directly (Nuxt file-based routing): `auth/`, `admin/`, `events/`, `volunteer/`, plus top-level pages like `settings.vue`, `inbox.vue`, `mobileClinic.vue`.
+- `components/` grouped by feature (`event/`, `map/`, `nav/`), not by type.
+- `map/Interactive.client.vue`'s `.client.vue` suffix means it's client-only (maplibre-gl doesn't SSR) — follow this pattern for any other browser-only integrations.
+- `lib/relativeFetch.ts` strips the origin off absolute URLs before calling Nuxt's `useFetch`, to avoid SSR/CSR host mismatches — prefer it over raw `useFetch`/`$fetch` when a URL might be absolute.
+- UI kit is `@nuxt/ui` (v4) with Tailwind v4; custom theme colors (`brand1`–`brand8` plus standard semantic colors) are declared in `nuxt.config.ts` under `ui.theme.colors` and expected to be defined in `app/assets/css/main.css`.
+- PWA config (icons, manifest, workbox) lives in `nuxt.config.ts` under the `pwa` key — `navigateFallbackAllowlist` deliberately excludes `/api` so API calls aren't intercepted by the service worker.
+
+## Deployment
+
+`main` and `stage` branches each have a GitHub Actions workflow (`.github/workflows/main.yml` / `stage.yml`) that builds a Docker image (arm64), pushes to ECR, and force-redeploys the corresponding ECS service — `main` → prod, `stage` → stage. There's no CI test/lint gate in these workflows currently, so run `pnpm lint` and `pnpm build` locally before merging.

--- a/app/pages/events/[id].vue
+++ b/app/pages/events/[id].vue
@@ -53,7 +53,11 @@ function cancelEdit() {
 }
 
 function formatForInput(isoString: string) {
-  return new Date(isoString).toISOString().slice(0, 16)
+  // datetime-local expects LOCAL wall-clock time, so build it from local
+  // components rather than toISOString() (which is UTC and would show a shifted time).
+  const d = new Date(isoString)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
 function onFilesChanged(files: File[]) {

--- a/prisma/migrations/20260714191036_add_calendar_event_id_to_event/migration.sql
+++ b/prisma/migrations/20260714191036_add_calendar_event_id_to_event/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "events" ADD COLUMN "calendarEventId" TEXT;

--- a/prisma/schema/event.prisma
+++ b/prisma/schema/event.prisma
@@ -8,6 +8,7 @@ model Event {
   location        Location @relation(fields: [locationId], references: [id])
   locationId      String
   calendarURL     String?
+  calendarEventId String?
   allowVolunteers Boolean
   allowAttendees  Boolean
   logsGenerated   Boolean @default(false)

--- a/server/api/events/[id]/index.delete.ts
+++ b/server/api/events/[id]/index.delete.ts
@@ -1,0 +1,51 @@
+import prisma from '#server/utils/prisma'
+import { deleteCalendarEvent } from '#server/utils/googleCalendar'
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+
+  if (!id) {
+    throw createError({ statusCode: 400, message: 'Missing event ID' })
+  }
+
+  const foundEvent = await prisma.event.findUnique({
+    where: { id },
+  })
+
+  if (!foundEvent) {
+    throw createError({ statusCode: 404, message: 'Event not found' })
+  }
+
+  // Best-effort: remove the entry from the shared Google Calendar first, using
+  // the requesting volunteer's OAuth session. A failure here never blocks the
+  // database deletion below.
+  if (foundEvent.calendarEventId) {
+    const userId = event.context.session?.user?.id
+    if (userId) {
+      await deleteCalendarEvent(userId, foundEvent.calendarEventId)
+    }
+  }
+
+  try {
+    // Remove dependent rows before the event itself. Only GuestRSVP cascades in
+    // the schema, so the other relations are cleared explicitly in a transaction.
+    await prisma.$transaction([
+      prisma.event_Asset.deleteMany({ where: { eventId: id } }),
+      prisma.rSVP.deleteMany({ where: { eventId: id } }),
+      prisma.volunteer_Hour_Log.deleteMany({ where: { eventId: id } }),
+      prisma.guestRSVP.deleteMany({ where: { eventId: id } }),
+      prisma.event.delete({ where: { id } }),
+    ])
+
+    console.log('🗑️ Event deleted:', id)
+    setResponseStatus(event, 204)
+    return null
+  }
+  catch (error) {
+    console.error('❌ Error deleting event:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Failed to delete event',
+    })
+  }
+})

--- a/server/api/events/[id]/index.patch.ts
+++ b/server/api/events/[id]/index.patch.ts
@@ -1,4 +1,5 @@
 import prisma from '#server/utils/prisma'
+import { createCalendarEvent, updateCalendarEvent } from '#server/utils/googleCalendar'
 
 // Geocode location using Nominatim
 async function geocodeLocation(location: string) {
@@ -128,6 +129,36 @@ export default defineEventHandler(async (event) => {
     })
 
     console.log('✅ Event updated:', updatedEvent)
+
+    // Best-effort: keep the shared Google Calendar in sync with the edit. If the
+    // event was never pushed (e.g. created before sync existed, or by a
+    // non-Google user), create it now; otherwise patch the existing entry.
+    const userId = event.context.session?.user?.id
+    if (userId) {
+      const calendarInput = {
+        title: updatedEvent.title,
+        description: updatedEvent.description,
+        location: updatedEvent.location?.address ?? null,
+        startTime: updatedEvent.startTime,
+        endTime: updatedEvent.endTime,
+      }
+
+      const calendarRef = foundEvent.calendarEventId
+        ? await updateCalendarEvent(userId, foundEvent.calendarEventId, calendarInput)
+        : await createCalendarEvent(userId, calendarInput)
+
+      if (calendarRef && calendarRef.id !== foundEvent.calendarEventId) {
+        return await prisma.event.update({
+          where: { id },
+          data: {
+            calendarEventId: calendarRef.id,
+            calendarURL: calendarRef.htmlLink,
+          },
+          include: { eventAssets: true, location: true },
+        })
+      }
+    }
+
     return updatedEvent
   }
   catch (error) {

--- a/server/api/events/index.post.ts
+++ b/server/api/events/index.post.ts
@@ -1,4 +1,5 @@
 import prisma from '#server/utils/prisma'
+import { createCalendarEvent } from '#server/utils/googleCalendar'
 
 // Geocode location using Nominatim
 async function geocodeLocation(location: string) {
@@ -96,6 +97,32 @@ export default defineEventHandler(async (event) => {
     })
 
     console.log('✅ Event created:', newEvent)
+
+    // Best-effort: push the new event to the shared Google Calendar using the
+    // creating volunteer's OAuth session. Failures never block event creation.
+    const userId = event.context.session?.user?.id
+    if (userId) {
+      const calendarRef = await createCalendarEvent(userId, {
+        title: newEvent.title,
+        description: newEvent.description,
+        location: body.location || null,
+        startTime: newEvent.startTime,
+        endTime: newEvent.endTime,
+      })
+
+      if (calendarRef) {
+        const synced = await prisma.event.update({
+          where: { id: newEvent.id },
+          data: {
+            calendarEventId: calendarRef.id,
+            calendarURL: calendarRef.htmlLink,
+          },
+          include: { eventAssets: true },
+        })
+        setResponseStatus(event, 201)
+        return synced
+      }
+    }
 
     setResponseStatus(event, 201)
     return newEvent

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -26,6 +26,13 @@ export const auth = betterAuth({
     google: {
       clientId: process.env.OAUTH_CLIENT_ID as string,
       clientSecret: process.env.OAUTH_CLIENT_SECRET as string,
+      // Request calendar write access so events can be pushed to the shared
+      // Abide Google Calendar. `accessType: 'offline'` + `prompt: 'consent'`
+      // ensure Google returns a refresh token, which better-auth stores on the
+      // Account and uses to mint fresh access tokens via getAccessToken().
+      scope: ['https://www.googleapis.com/auth/calendar.events'],
+      accessType: 'offline',
+      prompt: 'consent',
     },
   },
   hooks: {

--- a/server/utils/googleCalendar.ts
+++ b/server/utils/googleCalendar.ts
@@ -1,0 +1,217 @@
+import { auth } from './auth'
+
+// Pushes Abide events to a single shared Google Calendar (the org calendar
+// identified by GOOGLE_CALENDAR_ID). Writes are performed with the access token
+// of the volunteer who created/edited the event, so that volunteer's Google
+// account must have write access to the shared calendar. All calls are
+// best-effort: on any failure we log and return null/false so the surrounding
+// event operation (DB write) still succeeds.
+
+const CALENDAR_API = 'https://www.googleapis.com/calendar/v3'
+
+// Timezone Abide operates in — used so Google renders event times correctly.
+const CALENDAR_TIME_ZONE = 'America/Chicago'
+
+export interface CalendarEventInput {
+  title: string
+  description?: string | null
+  location?: string | null
+  startTime: Date
+  endTime: Date
+}
+
+export interface CalendarEventRef {
+  id: string
+  htmlLink: string | null
+}
+
+function getCalendarId(): string | null {
+  const id = process.env.GOOGLE_CALENDAR_ID
+  if (!id) {
+    console.warn('[googleCalendar] GOOGLE_CALENDAR_ID is not set — skipping calendar sync')
+    return null
+  }
+  return id
+}
+
+/**
+ * Resolve a valid Google access token for the given volunteer, refreshing it
+ * via the stored refresh token if it has expired. Returns null if the user has
+ * no linked Google account (e.g. they signed in with email OTP).
+ */
+async function getGoogleAccessToken(userId: string): Promise<string | null> {
+  try {
+    const result = await auth.api.getAccessToken({
+      body: { providerId: 'google', userId },
+    })
+    return result?.accessToken ?? null
+  }
+  catch (error) {
+    console.warn('[googleCalendar] No Google access token for volunteer', userId, error)
+    return null
+  }
+}
+
+// Format an absolute instant as a naive RFC3339 wall-clock string ("YYYY-MM-DDTHH:MM:SS")
+// in CALENDAR_TIME_ZONE, with NO trailing "Z"/offset. Google interprets this together
+// with the `timeZone` field below. Sending a UTC ("Z") dateTime *and* a timeZone makes
+// Google read the clock portion as local time, shifting the event by the zone offset.
+function toCalendarDateTime(date: Date): string {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: CALENDAR_TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(date)
+
+  const get = (type: string) => parts.find(p => p.type === type)?.value ?? '00'
+  // Some engines emit "24" for midnight when hour12 is false — normalize to "00".
+  const hour = get('hour') === '24' ? '00' : get('hour')
+
+  return `${get('year')}-${get('month')}-${get('day')}T${hour}:${get('minute')}:${get('second')}`
+}
+
+function toCalendarResource(input: CalendarEventInput) {
+  return {
+    summary: input.title,
+    description: input.description ?? undefined,
+    location: input.location ?? undefined,
+    start: {
+      dateTime: toCalendarDateTime(input.startTime),
+      timeZone: CALENDAR_TIME_ZONE,
+    },
+    end: {
+      dateTime: toCalendarDateTime(input.endTime),
+      timeZone: CALENDAR_TIME_ZONE,
+    },
+  }
+}
+
+/**
+ * Create a new entry on the shared Google Calendar. Returns the created event's
+ * id and htmlLink, or null if the sync was skipped or failed.
+ */
+export async function createCalendarEvent(
+  userId: string,
+  input: CalendarEventInput,
+): Promise<CalendarEventRef | null> {
+  const calendarId = getCalendarId()
+  if (!calendarId) return null
+
+  const accessToken = await getGoogleAccessToken(userId)
+  if (!accessToken) return null
+
+  try {
+    const response = await fetch(
+      `${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(toCalendarResource(input)),
+      },
+    )
+
+    if (!response.ok) {
+      console.warn('[googleCalendar] Failed to create calendar event:', response.status, await response.text())
+      return null
+    }
+
+    const created = await response.json()
+    console.log('📆 Pushed event to shared calendar:', created.id)
+    return { id: created.id, htmlLink: created.htmlLink ?? null }
+  }
+  catch (error) {
+    console.error('[googleCalendar] Error creating calendar event:', error)
+    return null
+  }
+}
+
+/**
+ * Update an existing shared-calendar entry to match the Abide event. Returns the
+ * updated event ref, or null if the sync was skipped or failed.
+ */
+export async function updateCalendarEvent(
+  userId: string,
+  calendarEventId: string,
+  input: CalendarEventInput,
+): Promise<CalendarEventRef | null> {
+  const calendarId = getCalendarId()
+  if (!calendarId) return null
+
+  const accessToken = await getGoogleAccessToken(userId)
+  if (!accessToken) return null
+
+  try {
+    const response = await fetch(
+      `${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(calendarEventId)}`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(toCalendarResource(input)),
+      },
+    )
+
+    if (!response.ok) {
+      console.warn('[googleCalendar] Failed to update calendar event:', response.status, await response.text())
+      return null
+    }
+
+    const updated = await response.json()
+    console.log('📆 Updated shared calendar event:', updated.id)
+    return { id: updated.id, htmlLink: updated.htmlLink ?? null }
+  }
+  catch (error) {
+    console.error('[googleCalendar] Error updating calendar event:', error)
+    return null
+  }
+}
+
+/**
+ * Remove a shared-calendar entry. Returns true if the entry was deleted (or was
+ * already gone), false if the sync was skipped or failed.
+ */
+export async function deleteCalendarEvent(
+  userId: string,
+  calendarEventId: string,
+): Promise<boolean> {
+  const calendarId = getCalendarId()
+  if (!calendarId) return false
+
+  const accessToken = await getGoogleAccessToken(userId)
+  if (!accessToken) return false
+
+  try {
+    const response = await fetch(
+      `${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(calendarEventId)}`,
+      {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    )
+
+    // 200/204 = deleted, 410 = already gone — both are fine.
+    if (response.ok || response.status === 410) {
+      console.log('📆 Removed shared calendar event:', calendarEventId)
+      return true
+    }
+
+    console.warn('[googleCalendar] Failed to delete calendar event:', response.status, await response.text())
+    return false
+  }
+  catch (error) {
+    console.error('[googleCalendar] Error deleting calendar event:', error)
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

Mirrors event create / update / delete to a single shared Google Calendar (`GOOGLE_CALENDAR_ID`), written with the acting volunteer's Google OAuth token. Sync is **best-effort**: if the volunteer signed in via email OTP (no Google token) or the Calendar API fails, the DB operation still succeeds and the calendar is simply left unchanged.

## Changes

- **`server/utils/googleCalendar.ts`** (new) — `create`/`update`/`deleteCalendarEvent` helpers. Resolves a fresh access token via `auth.api.getAccessToken`, formats times as wall-clock RFC3339 in `America/Chicago` (avoids UTC offset shifts), logs and no-ops on any failure.
- **`server/api/events/`** — wire sync into `index.post.ts` (POST) and `[id]/index.patch.ts` (PATCH); add new `[id]/index.delete.ts` (DELETE) which removes the calendar entry then cascades dependent rows in a transaction.
- **`prisma/schema/event.prisma`** + migration — add `Event.calendarEventId` to store the Google event id (alongside existing `calendarURL`) for later update/delete.
- **`server/utils/auth.ts`** — request the `calendar.events` scope with `accessType: 'offline'` + `prompt: 'consent'` so better-auth stores a refresh token.
- **`app/pages/events/[id].vue`** — fix `datetime-local` formatting to use local wall-clock components instead of `toISOString()` (which showed a UTC-shifted time).
- **`.env.example`** — document `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` / `GOOGLE_CALENDAR_ID`.
- **`CLAUDE.md`** (new) — repo guidance for Claude Code.

## Notes

- Requires `GOOGLE_CALENDAR_ID` set and the event-creating volunteers to have write access to that shared calendar.
- Pre-existing lint errors remain in `auth.ts` / `events/[id].vue` on lines untouched by this change (no CI lint gate in this repo); the new code is lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
