### PR TITLE
feat: implement functional settings page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,11 @@ OAUTH_CLIENT_SECRET= # Google OAuth 2.0 client secret
 # e.g. abc123@group.calendar.google.com). Volunteers who create events must have
 # write access to this calendar for the push to succeed.
 GOOGLE_CALENDAR_ID=
+
+# Web Push (VAPID). Generate a keypair with `pnpm push:keys` and paste the
+# output below — the same pair must be used across restarts, or every existing
+# subscription is invalidated. Leaving these blank disables push notifications;
+# the settings toggle then shows as unavailable rather than erroring.
+VAPID_PUBLIC_KEY=    # Public key, also exposed to the client to subscribe
+VAPID_PRIVATE_KEY=   # Private key, server-only — never commit a real value
+VAPID_SUBJECT=       # Contact URI for push services, e.g. mailto:info@abidewomen.org

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,17 +42,27 @@ Copy `.env.example` to `.env` before running anything. Required vars: `BETTER_AU
 
 When an event is created/updated/deleted, `server/utils/googleCalendar.ts` mirrors it to a single shared Google Calendar (`GOOGLE_CALENDAR_ID`). Writes use the acting volunteer's Google OAuth token — obtained via `auth.api.getAccessToken({ body: { providerId: 'google', userId } })`, which refreshes using the stored refresh token — so the Google provider requests the `calendar.events` scope with `accessType: 'offline'` + `prompt: 'consent'` (in `auth.ts`). The Google event id is stored on `Event.calendarEventId` (and its link on `Event.calendarURL`) for later update/delete. Sync is **best-effort**: if the acting volunteer signed in with email OTP (no Google token) or the Calendar API fails, the DB operation still succeeds and the calendar is simply not updated.
 
+### Web Push notifications
+
+Push is plain Web Push (VAPID) through the PWA's own service worker — no APNs certificate or FCM project. `pnpm push:keys` generates the `VAPID_PUBLIC_KEY`/`VAPID_PRIVATE_KEY` pair; the same pair must persist across restarts or every stored subscription is invalidated. With the keys unset, `pushConfigured` is false, sending is a no-op, and the settings toggle reports push as unavailable instead of erroring.
+
+- `server/utils/push.ts` — `sendPushToUsers(userIds, 'GENERAL' | 'VOLUNTEER', payload)` is the entry point feature code should call. It honours each user's `pushEnabled`/`pushScope`, fans out across all their devices, and prunes subscriptions the push service reports as gone (404/410). Best-effort: it never throws.
+- `public/push-sw.js` holds the `push`/`notificationclick` handlers, pulled into the generated Workbox service worker via `pwa.workbox.importScripts` in `nuxt.config.ts`. It's plain JS in `public/` because it runs in the service worker scope with no bundler pass.
+- `app/composables/usePushNotifications.ts` is the client half (permission prompt, subscribe/unsubscribe, iOS "add to Home Screen" detection).
+- `web-push` and its ASN.1 deps are CommonJS and must stay in `nitro.externals.inline` — left external, Nitro's dev server fails to load them and **every** server route 500s.
+
 ## Architecture
 
 This is a Nuxt 4 app, so the app source root is `app/` (pages, components, layouts, middleware, lib, types), while `server/` holds Nitro server routes/middleware/utils and is a separate root — cross-referencing it from `app/` code goes through the `#server` path alias (e.g. `import { auth } from '#server/utils/auth'`), not a relative path.
 
 ### Auth (better-auth)
 
-- `server/utils/auth.ts` configures `better-auth` with the Prisma adapter, pointed at a custom `Volunteer` model (via `user: { modelName: 'Volunteer', fields: { image: 'imageURL' } }`) instead of the default `User` model — the schema's own `User` model (`prisma/schema/user.prisma`) is a separate concept representing RSVP guests/contacts, not the authenticated principal.
+- `server/utils/auth.ts` configures `better-auth` with the Prisma adapter against the `User` model (via `user: { modelName: 'User', fields: { image: 'imageURL' } }`). So `session.user.id` is a `User.id`, and a volunteer record is reached with `prisma.volunteer.findUnique({ where: { userId: session.user.id } })` — `Volunteer` hangs off `User`, it is not the authenticated principal itself.
 - Two auth methods are wired: Google OAuth (`socialProviders.google`) and email OTP (`emailOTP` plugin, `disableSignUp: true` — sign-up must happen through the app's own sign-up flow, not automatically on first OTP request). OTP emails are sent via a nodemailer SMTP transport.
 - `server/api/auth/[...all].ts` mounts the better-auth handler for all `/api/auth/*` routes.
 - `server/middleware/authenticated.ts` runs on every request, attaches `event.context.session`, and hard-redirects unauthenticated requests to `/auth/login` for any path under `/volunteer` or `/api/volunteer`.
-- `app/middleware/auth.ts` is the client-side route guard: it calls `/api/auth/get-session` and redirects to `/auth/login` unless the route is in its `publicRoutes` allowlist. Add new public pages to that list explicitly.
+- `app/middleware/auth.ts` is an **opt-in** (non-global) route guard: it calls `/api/auth/get-session` and redirects to `/auth/login` unless the route is in its `publicRoutes` allowlist. Pages that need a session must declare `middleware: 'auth'` in `definePageMeta` (see `settings.vue`, `inbox.vue`) — it does not apply automatically.
+- `app/middleware/auth.global.ts` runs on every route and enforces the role requirements in its `routeRoles` map (`/admin`, `/events/manage`, `/volunteer`, `/volunteer-application`). It only guards those prefixes; everything else is unauthenticated unless the page opts into `auth`.
 - `server/utils/auth-client.ts` exports the `better-auth/vue` client (`authClient`) for use in components/pages.
 
 ### Data model (`prisma/schema/*.prisma`)

--- a/app/components/settings/Section.vue
+++ b/app/components/settings/Section.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+/** Card wrapper shared by every block on the settings page. */
+defineProps<{
+  title: string
+  description?: string
+  /** Renders the header in the error colour, for destructive sections. */
+  danger?: boolean
+}>()
+</script>
+
+<template>
+  <section
+    class="rounded-3xl border px-5 py-5 shadow-md"
+    :class="danger
+      ? 'border-error/40 bg-error/5 dark:border-error/40 dark:bg-error/10'
+      : 'border-gray-200 bg-white dark:border-gray-700/60 dark:bg-gray-900/60'"
+  >
+    <header class="mb-4">
+      <h2
+        class="text-lg font-semibold"
+        :class="danger ? 'text-error' : 'text-brand4 dark:text-brand8'"
+      >
+        {{ title }}
+      </h2>
+      <p
+        v-if="description"
+        class="mt-1 text-xs font-normal text-gray-500 dark:text-gray-400"
+      >
+        {{ description }}
+      </p>
+    </header>
+
+    <div class="space-y-4">
+      <slot />
+    </div>
+  </section>
+</template>

--- a/app/composables/usePushNotifications.ts
+++ b/app/composables/usePushNotifications.ts
@@ -1,0 +1,134 @@
+/**
+ * Client half of Web Push: browser permission + subscription lifecycle,
+ * kept in sync with the `push_subscriptions` rows on the server.
+ *
+ * The server half lives in server/utils/push.ts and server/api/push/*.
+ */
+
+/** Push services want the VAPID key as a Uint8Array, not the base64url string. */
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const raw = atob(base64)
+  return Uint8Array.from([...raw].map(char => char.charCodeAt(0)))
+}
+
+/**
+ * - `unknown` — still determining support (SSR, or the service worker hasn't resolved)
+ * - `supported` — everything needed is present
+ * - `unsupported` — browser can't do Web Push at all
+ * - `requires-install` — iOS Safari in a tab: push only works once added to the home screen
+ * - `not-configured` — server has no VAPID keys configured
+ */
+export type PushSupport = 'unknown' | 'supported' | 'unsupported' | 'requires-install' | 'not-configured'
+
+export function usePushNotifications() {
+  const config = useRuntimeConfig()
+  const vapidPublicKey = config.public.vapidPublicKey as string
+
+  const support = ref<PushSupport>('unknown')
+  const permission = ref<NotificationPermission>('default')
+  const isSubscribed = ref(false)
+  const isBusy = ref(false)
+
+  function detectSupport(): PushSupport {
+    if (!import.meta.client) return 'unknown'
+    if (!vapidPublicKey) return 'not-configured'
+
+    const hasApis = 'serviceWorker' in navigator && 'PushManager' in window && 'Notification' in window
+    if (hasApis) return 'supported'
+
+    // iOS only exposes PushManager to home-screen web apps. Detect that case
+    // specifically so we can tell the user to install rather than "unsupported".
+    const isIos = /iP(hone|ad|od)/.test(navigator.userAgent)
+    const isStandalone = window.matchMedia('(display-mode: standalone)').matches
+      || (window.navigator as Navigator & { standalone?: boolean }).standalone === true
+    if (isIos && !isStandalone) return 'requires-install'
+
+    return 'unsupported'
+  }
+
+  async function getRegistration(): Promise<ServiceWorkerRegistration | null> {
+    if (!('serviceWorker' in navigator)) return null
+    return navigator.serviceWorker.ready
+  }
+
+  async function refresh() {
+    support.value = detectSupport()
+    if (support.value !== 'supported') return
+
+    permission.value = Notification.permission
+
+    const registration = await getRegistration()
+    const existing = await registration?.pushManager.getSubscription()
+    isSubscribed.value = Boolean(existing)
+  }
+
+  /**
+   * Asks for permission if needed, creates a push subscription, and registers
+   * it server-side. Returns false if the user denied or the browser can't.
+   */
+  async function subscribe(): Promise<boolean> {
+    if (support.value !== 'supported') return false
+
+    isBusy.value = true
+    try {
+      permission.value = await Notification.requestPermission()
+      if (permission.value !== 'granted') return false
+
+      const registration = await getRegistration()
+      if (!registration) return false
+
+      // Reuse the device's existing subscription when there is one, so the
+      // endpoint (and therefore the server row) stays stable.
+      const subscription = await registration.pushManager.getSubscription()
+        ?? await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: urlBase64ToUint8Array(vapidPublicKey) as BufferSource,
+        })
+
+      await $fetch('/api/push/subscribe', {
+        method: 'POST',
+        body: subscription.toJSON(),
+      })
+
+      isSubscribed.value = true
+      return true
+    }
+    catch (error) {
+      console.error('[push] subscribe failed', error)
+      return false
+    }
+    finally {
+      isBusy.value = false
+    }
+  }
+
+  /** Tears down the device subscription and removes it server-side. */
+  async function unsubscribe(): Promise<void> {
+    isBusy.value = true
+    try {
+      const registration = await getRegistration()
+      const subscription = await registration?.pushManager.getSubscription()
+      if (!subscription) {
+        isSubscribed.value = false
+        return
+      }
+
+      const { endpoint } = subscription
+      await subscription.unsubscribe()
+      await $fetch('/api/push/unsubscribe', { method: 'POST', body: { endpoint } })
+      isSubscribed.value = false
+    }
+    catch (error) {
+      console.error('[push] unsubscribe failed', error)
+    }
+    finally {
+      isBusy.value = false
+    }
+  }
+
+  onMounted(refresh)
+
+  return { support, permission, isSubscribed, isBusy, subscribe, unsubscribe, refresh }
+}

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -1,59 +1,655 @@
 <script setup lang="ts">
+import { authClient } from '#server/utils/auth-client'
+import {
+  languageItems,
+  genderItems,
+  ethinicityItems,
+  availabilityItems,
+  volunteerAreaItems,
+  certificationItems,
+} from '~/types/volunteer/volunteer-application.type'
+
 definePageMeta({
   layout: 'secondary',
+  // This page shows personal details and can delete the account, so it must
+  // not render for signed-out visitors. `auth` is opt-in per page (see
+  // app/middleware/auth.ts); auth.global.ts only guards role-prefixed routes.
+  middleware: 'auth',
 })
 
-const colorMode = useColorMode();
+const toast = useToast()
+const colorMode = useColorMode()
 
-// type for the select
-type NotificationType = 'General Events' | 'Volunteer Events' | 'Both'
+// The session cookie has to be forwarded explicitly or these come back empty
+// during SSR.
+const headers = import.meta.server ? useRequestHeaders(['cookie']) : undefined
 
-const notificationEnabled = ref(true)
-const notificationType = ref<NotificationType>('General Events')
+type Me = {
+  id: string
+  name: string | null
+  email: string
+  phone: string | null
+  pushEnabled: boolean
+  pushScope: 'GENERAL' | 'VOLUNTEER' | 'BOTH'
+}
 
-const notificationOptions = [
-  { label: 'General Events', value: 'general' },
-  { label: 'Volunteer Events', value: 'volunteer' },
-  { label: 'Both', value: 'both' },
+type VolunteerProfile = {
+  approvalStatus: 'PENDING' | 'APPROVED' | 'REJECTED'
+  gender: string | null
+  ethinicity: string | null
+  languages: string[]
+  availability: string[]
+  volunteerAreas: string[]
+  certifications: string[]
+  otherVolunteerAreaDescription: string | null
+  otherCertificationDescription: string | null
+  emergencyContactName1: string | null
+  emergencyContactPhone1: string | null
+  emergencyContactName2: string | null
+  emergencyContactPhone2: string | null
+}
+
+const { data: user } = await useFetch<Me>('/api/user/me', { headers })
+const { data: roles } = await useFetch<string[]>('/api/user/roles', { headers, default: () => [] })
+const { data: volunteer } = await useFetch<VolunteerProfile | null>('/api/volunteer/me', {
+  headers,
+  default: () => null,
+})
+
+// Volunteer-only settings stay hidden for plain users; both checks matter,
+// since the role and the application record are written separately.
+const isVolunteer = computed(() => roles.value.includes('volunteer') && volunteer.value !== null)
+
+/* ------------------------------------------------------------------ profile */
+
+const profileForm = reactive({
+  name: user.value?.name ?? '',
+  phone: user.value?.phone ?? '',
+})
+const savingProfile = ref(false)
+
+async function saveProfile() {
+  savingProfile.value = true
+  try {
+    const updated = await $fetch<Me>('/api/user/me', {
+      method: 'PATCH',
+      body: { name: profileForm.name, phone: profileForm.phone },
+    })
+    user.value = updated
+    profileForm.name = updated.name ?? ''
+    profileForm.phone = updated.phone ?? ''
+    toast.add({ title: 'Profile updated', color: 'success', icon: 'i-lucide-check' })
+  }
+  catch (error) {
+    toast.add({
+      title: 'Could not save profile',
+      description: errorMessage(error),
+      color: 'error',
+      icon: 'i-lucide-alert-circle',
+    })
+  }
+  finally {
+    savingProfile.value = false
+  }
+}
+
+/* --------------------------------------------------------------- appearance */
+
+const themeItems = [
+  { label: 'Match system', value: 'system' },
+  { label: 'Light', value: 'light' },
+  { label: 'Dark', value: 'dark' },
 ]
 
-const switchColor = computed(() =>
-  colorMode.value === 'dark' ? 'brand5' : 'brand7'
-)
+// `preference` is what the user picked ('system' included); `colorMode.value`
+// is the resolved light/dark. Binding to preference is what makes "match
+// system" stick across reloads.
+const themePreference = computed({
+  get: () => colorMode.preference,
+  set: (value: string) => { colorMode.preference = value },
+})
+
+/* ------------------------------------------------------- push notifications */
+
+const { support, permission, isSubscribed, isBusy: pushBusy, subscribe, unsubscribe, refresh: refreshPush }
+  = usePushNotifications()
+
+const pushEnabled = ref(user.value?.pushEnabled ?? false)
+const pushScope = ref<Me['pushScope']>(user.value?.pushScope ?? 'BOTH')
+const sendingTest = ref(false)
+
+const pushScopeItems = [
+  { label: 'General events', value: 'GENERAL' },
+  { label: 'Volunteer events', value: 'VOLUNTEER' },
+  { label: 'Both', value: 'BOTH' },
+]
+
+const pushUnavailableReason = computed(() => {
+  switch (support.value) {
+    case 'not-configured':
+      return 'Push notifications aren\'t configured on this server yet.'
+    case 'requires-install':
+      return 'To get notifications on iPhone or iPad, add Abide Connect to your Home Screen first, then open it from there.'
+    case 'unsupported':
+      return 'This browser doesn\'t support push notifications.'
+    default:
+      return null
+  }
+})
+
+const pushBlocked = computed(() => permission.value === 'denied')
+
+async function savePushPreferences(patch: Partial<Pick<Me, 'pushEnabled' | 'pushScope'>>) {
+  const updated = await $fetch<Me>('/api/user/me', { method: 'PATCH', body: patch })
+  user.value = updated
+  pushEnabled.value = updated.pushEnabled
+  pushScope.value = updated.pushScope
+}
+
+async function onPushToggle(value: boolean) {
+  try {
+    if (value) {
+      // Register the device first — if the user dismisses the browser prompt
+      // there's nothing to enable, so don't record the preference.
+      const granted = await subscribe()
+      if (!granted) {
+        pushEnabled.value = false
+        await refreshPush()
+        toast.add({
+          title: 'Notifications not enabled',
+          description: pushBlocked.value
+            ? 'Notifications are blocked for this site. Turn them back on in your browser settings.'
+            : 'Permission was not granted.',
+          color: 'warning',
+          icon: 'i-lucide-bell-off',
+        })
+        return
+      }
+      await savePushPreferences({ pushEnabled: true })
+      toast.add({ title: 'Notifications on', color: 'success', icon: 'i-lucide-bell' })
+    }
+    else {
+      await unsubscribe()
+      await savePushPreferences({ pushEnabled: false })
+      toast.add({ title: 'Notifications off', color: 'neutral', icon: 'i-lucide-bell-off' })
+    }
+  }
+  catch (error) {
+    pushEnabled.value = !value
+    toast.add({
+      title: 'Could not update notifications',
+      description: errorMessage(error),
+      color: 'error',
+      icon: 'i-lucide-alert-circle',
+    })
+  }
+}
+
+async function onPushScopeChange(value: Me['pushScope']) {
+  try {
+    await savePushPreferences({ pushScope: value })
+    toast.add({ title: 'Notification preference saved', color: 'success', icon: 'i-lucide-check' })
+  }
+  catch (error) {
+    pushScope.value = user.value?.pushScope ?? 'BOTH'
+    toast.add({ title: 'Could not save preference', description: errorMessage(error), color: 'error' })
+  }
+}
+
+async function sendTestNotification() {
+  sendingTest.value = true
+  try {
+    await $fetch('/api/push/test', { method: 'POST' })
+    toast.add({ title: 'Test notification sent', color: 'success', icon: 'i-lucide-send' })
+  }
+  catch (error) {
+    toast.add({ title: 'Test failed', description: errorMessage(error), color: 'error' })
+  }
+  finally {
+    sendingTest.value = false
+  }
+}
+
+/* ---------------------------------------------------- volunteer application */
+
+const volunteerForm = reactive({
+  gender: volunteer.value?.gender ?? undefined,
+  ethinicity: volunteer.value?.ethinicity ?? undefined,
+  languages: volunteer.value?.languages ?? [],
+  availability: volunteer.value?.availability ?? [],
+  volunteerAreas: volunteer.value?.volunteerAreas ?? [],
+  certifications: volunteer.value?.certifications ?? [],
+  otherVolunteerAreaDescription: volunteer.value?.otherVolunteerAreaDescription ?? '',
+  otherCertificationDescription: volunteer.value?.otherCertificationDescription ?? '',
+  emergencyContactName1: volunteer.value?.emergencyContactName1 ?? '',
+  emergencyContactPhone1: volunteer.value?.emergencyContactPhone1 ?? '',
+  emergencyContactName2: volunteer.value?.emergencyContactName2 ?? '',
+  emergencyContactPhone2: volunteer.value?.emergencyContactPhone2 ?? '',
+})
+const savingVolunteer = ref(false)
+
+const approvalBadge = computed(() => {
+  switch (volunteer.value?.approvalStatus) {
+    case 'APPROVED': return { label: 'Approved', color: 'success' as const }
+    case 'REJECTED': return { label: 'Not approved', color: 'error' as const }
+    default: return { label: 'Pending review', color: 'warning' as const }
+  }
+})
+
+async function saveVolunteer() {
+  savingVolunteer.value = true
+  try {
+    await $fetch('/api/volunteer/me', { method: 'PATCH', body: { ...volunteerForm } })
+    toast.add({ title: 'Volunteer details updated', color: 'success', icon: 'i-lucide-check' })
+  }
+  catch (error) {
+    toast.add({
+      title: 'Could not save volunteer details',
+      description: errorMessage(error),
+      color: 'error',
+      icon: 'i-lucide-alert-circle',
+    })
+  }
+  finally {
+    savingVolunteer.value = false
+  }
+}
+
+/* ------------------------------------------------------------------ account */
+
+const deleteModalOpen = ref(false)
+const deleting = ref(false)
+
+async function deleteAccount() {
+  deleting.value = true
+  try {
+    await $fetch('/api/user/me', { method: 'DELETE' })
+    // The session rows are gone, so signOut may 401 — the cookie is inert
+    // either way and the hard navigation below clears client state.
+    await authClient.signOut().catch(() => {})
+    await navigateTo('/auth/login', { external: true })
+  }
+  catch (error) {
+    deleting.value = false
+    deleteModalOpen.value = false
+    toast.add({
+      title: 'Could not delete account',
+      description: errorMessage(error),
+      color: 'error',
+      icon: 'i-lucide-alert-circle',
+    })
+  }
+}
+
+async function signOut() {
+  await authClient.signOut().catch(() => {})
+  await navigateTo('/auth/login', { external: true })
+}
+
+/** Pulls the human-readable message out of an $fetch error. */
+function errorMessage(error: unknown): string {
+  return (error as { statusMessage?: string }).statusMessage
+    ?? (error as { data?: { statusMessage?: string } }).data?.statusMessage
+    ?? (error as { message?: string }).message
+    ?? 'Please try again.'
+}
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col bg-white dark:bg-gray-900">
-    <!-- top nav bar with back button -->
-    <main class="flex-1 px-5 pt-20 pb-24">
-      <h2 class="text-xl font-semibold mb-6 text-brand7 dark:text-teal-400">
-        Event Notifications
-      </h2>
+  <div class="min-h-screen bg-white dark:bg-gray-900">
+    <main class="mx-auto flex w-full max-w-2xl flex-col gap-5 px-5 pt-16 pb-28">
+      <h1 class="text-2xl font-bold text-brand4 dark:text-brand8">
+        Settings
+      </h1>
 
-      <section class="space-y-5">
-        <div class="w-full rounded-3xl border border-gray-800/70 bg-slate-100 px-4 py-4 flex items-center justify-between dark:bg-gray-900/60 dark:border-gray-700/60 shadow-md">
-          <span class="text-sm font-semibold text-">Enable Notifications</span>
-
-          <USwitch
-            v-model="notificationEnabled"
-            :color="switchColor"
+      <!-- Profile ------------------------------------------------------- -->
+      <SettingsSection
+        title="Your details"
+        description="How Abide staff get in touch with you."
+      >
+        <UFormField label="Name">
+          <UInput
+            v-model="profileForm.name"
+            placeholder="Full name"
+            autocomplete="name"
+            class="w-full"
           />
-        </div>
-        <!-- notification type -->
-        <div
-          v-if="notificationEnabled"
-          class="w-full rounded-3xl border border-gray-2-400 bg-white px-4 py-3 flex items-center justify-between  dark:bg-gray-900/60 dark:border-gray-700/60 shadow-md"
+        </UFormField>
+
+        <UFormField
+          label="Phone number"
+          description="Optional."
         >
-          <span class="text-sm font-semibold text-brand4 dark:text-white">Notification Type</span>
+          <UInput
+            v-model="profileForm.phone"
+            type="tel"
+            placeholder="(555) 123-4567"
+            autocomplete="tel"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField
+          label="Email"
+          description="Your email is how you sign in, so it can't be changed here. Contact Abide staff if you need it updated."
+        >
+          <UInput
+            :model-value="user?.email ?? ''"
+            disabled
+            class="w-full"
+          />
+        </UFormField>
+
+        <UButton
+          label="Save details"
+          color="brand4"
+          :loading="savingProfile"
+          @click="saveProfile"
+        />
+      </SettingsSection>
+
+      <!-- Appearance ---------------------------------------------------- -->
+      <SettingsSection
+        title="Appearance"
+        description="Applies to this device."
+      >
+        <div class="flex items-center justify-between gap-4">
+          <span class="text-sm font-semibold">Theme</span>
           <USelect
-            v-model="notificationType"
-            :items="notificationOptions"
-            size="sm"
-            class="w-40"
-            color="brand6"
+            v-model="themePreference"
+            :items="themeItems"
+            value-key="value"
+            class="w-44"
           />
         </div>
-      </section>
+      </SettingsSection>
+
+      <!-- Notifications ------------------------------------------------- -->
+      <SettingsSection
+        title="Event notifications"
+        description="Push notifications about upcoming events, sent to this device."
+      >
+        <UAlert
+          v-if="pushUnavailableReason"
+          color="neutral"
+          variant="subtle"
+          icon="i-lucide-info"
+          :description="pushUnavailableReason"
+        />
+
+        <template v-else>
+          <UAlert
+            v-if="pushBlocked"
+            color="warning"
+            variant="subtle"
+            icon="i-lucide-bell-off"
+            description="Notifications are blocked for this site in your browser settings. You'll need to allow them there before turning this on."
+          />
+
+          <div class="flex items-center justify-between gap-4">
+            <span class="text-sm font-semibold">Enable notifications</span>
+            <USwitch
+              v-model="pushEnabled"
+              color="brand4"
+              :disabled="pushBusy || pushBlocked"
+              @update:model-value="onPushToggle"
+            />
+          </div>
+
+          <div
+            v-if="pushEnabled"
+            class="flex items-center justify-between gap-4"
+          >
+            <span class="text-sm font-semibold">Notify me about</span>
+            <USelect
+              v-model="pushScope"
+              :items="pushScopeItems"
+              value-key="value"
+              class="w-44"
+              @update:model-value="onPushScopeChange"
+            />
+          </div>
+
+          <UButton
+            v-if="pushEnabled && isSubscribed"
+            label="Send a test notification"
+            icon="i-lucide-send"
+            color="neutral"
+            variant="subtle"
+            size="sm"
+            :loading="sendingTest"
+            @click="sendTestNotification"
+          />
+        </template>
+      </SettingsSection>
+
+      <!-- Volunteer application ----------------------------------------- -->
+      <SettingsSection
+        v-if="isVolunteer"
+        title="Volunteer application"
+        description="Update what you told us when you applied."
+      >
+        <div class="flex items-center gap-2">
+          <span class="text-sm font-semibold">Application status</span>
+          <UBadge
+            :color="approvalBadge.color"
+            variant="subtle"
+            :label="approvalBadge.label"
+          />
+        </div>
+
+        <UFormField label="Languages">
+          <USelect
+            v-model="volunteerForm.languages"
+            :items="languageItems"
+            value-key="id"
+            multiple
+            placeholder="What languages do you speak?"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField label="Gender">
+          <USelect
+            v-model="volunteerForm.gender"
+            :items="genderItems"
+            value-key="id"
+            placeholder="What is your gender?"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField label="Ethinicity">
+          <USelect
+            v-model="volunteerForm.ethinicity"
+            :items="ethinicityItems"
+            value-key="id"
+            placeholder="What is your ethinicity?"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField label="Availability">
+          <USelect
+            v-model="volunteerForm.availability"
+            :items="availabilityItems"
+            value-key="id"
+            multiple
+            placeholder="When are you available?"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField label="Areas you'd like to help with">
+          <USelect
+            v-model="volunteerForm.volunteerAreas"
+            :items="volunteerAreaItems"
+            value-key="id"
+            multiple
+            placeholder="Select all that apply"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField
+          v-if="volunteerForm.volunteerAreas.includes('OTHER')"
+          label="Describe the work you'd like to volunteer for"
+        >
+          <UTextarea
+            v-model="volunteerForm.otherVolunteerAreaDescription"
+            :rows="3"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField label="Certifications">
+          <USelect
+            v-model="volunteerForm.certifications"
+            :items="certificationItems"
+            value-key="id"
+            multiple
+            placeholder="Select all that apply"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField
+          v-if="volunteerForm.certifications.includes('OTHER')"
+          label="Ideas or services you'd like to propose"
+        >
+          <UTextarea
+            v-model="volunteerForm.otherCertificationDescription"
+            :rows="3"
+            class="w-full"
+          />
+        </UFormField>
+
+        <USeparator />
+
+        <h3 class="text-sm font-semibold text-brand4 dark:text-brand8">
+          Emergency contacts
+        </h3>
+
+        <UFormField label="Primary contact name">
+          <UInput
+            v-model="volunteerForm.emergencyContactName1"
+            placeholder="Full name"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField label="Primary contact phone">
+          <UInput
+            v-model="volunteerForm.emergencyContactPhone1"
+            type="tel"
+            placeholder="Phone number"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField
+          label="Secondary contact name"
+          description="Optional."
+        >
+          <UInput
+            v-model="volunteerForm.emergencyContactName2"
+            placeholder="Full name"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField
+          label="Secondary contact phone"
+          description="Optional."
+        >
+          <UInput
+            v-model="volunteerForm.emergencyContactPhone2"
+            type="tel"
+            placeholder="Phone number"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UAlert
+          color="neutral"
+          variant="subtle"
+          icon="i-lucide-lock"
+          title="Agreements are locked"
+          description="The Code of Conduct, NDA, handbook and background check agreements you signed when applying can't be changed here. Contact Abide staff if something needs to be revisited."
+        />
+
+        <UButton
+          label="Save volunteer details"
+          color="brand4"
+          :loading="savingVolunteer"
+          @click="saveVolunteer"
+        />
+      </SettingsSection>
+
+      <!-- Account ------------------------------------------------------- -->
+      <SettingsSection title="Account">
+        <UButton
+          label="Sign out"
+          icon="i-lucide-log-out"
+          color="neutral"
+          variant="subtle"
+          @click="signOut"
+        />
+      </SettingsSection>
+
+      <SettingsSection
+        danger
+        title="Delete account"
+        description="Permanently removes your account and everything attached to it. This can't be undone."
+      >
+        <UButton
+          label="Delete my account"
+          icon="i-lucide-trash-2"
+          color="error"
+          variant="subtle"
+          @click="deleteModalOpen = true"
+        />
+      </SettingsSection>
     </main>
+
+    <UModal
+      v-model:open="deleteModalOpen"
+      title="Delete your account?"
+      description="This is permanent and cannot be undone."
+    >
+      <template #body>
+        <div class="space-y-3 text-sm">
+          <p>Deleting your account will permanently remove:</p>
+          <ul class="list-disc space-y-1 pl-5 text-gray-600 dark:text-gray-400">
+            <li>your profile and sign-in access</li>
+            <li>your event sign-ups and RSVPs</li>
+            <li v-if="isVolunteer">
+              your volunteer application and logged hours
+            </li>
+          </ul>
+          <p class="font-semibold">
+            You will not be able to recover any of it.
+          </p>
+        </div>
+      </template>
+
+      <template #footer>
+        <div class="flex w-full justify-end gap-2">
+          <UButton
+            label="Cancel"
+            color="neutral"
+            variant="ghost"
+            :disabled="deleting"
+            @click="deleteModalOpen = false"
+          />
+          <UButton
+            label="Yes, delete my account"
+            color="error"
+            :loading="deleting"
+            @click="deleteAccount"
+          />
+        </div>
+      </template>
+    </UModal>
   </div>
 </template>

--- a/app/types/volunteer/volunteer-application.type.ts
+++ b/app/types/volunteer/volunteer-application.type.ts
@@ -34,6 +34,10 @@ const volunteerApplicationSchema = z.object({
 
   emergencyContactPhone1: z.string({ message: "Please enter the phone number of your emergency contact."}),
 
+  emergencyContactName2: z.string().nullable().optional(),
+
+  emergencyContactPhone2: z.string().nullable().optional(),
+
   ageEligibilityAcknowledgement: z.boolean({ message: 'You must confirm your eligibility' })
     .refine(v => v === true, { message: 'You must confirm your eligibility' }),
 
@@ -77,6 +81,10 @@ export const volunteerApplicationStepSchemas = [
   volunteerApplicationSchema.pick({
     emergencyContactName1: true,
     emergencyContactPhone1: true,
+    // Both step-2 forms render these, and `.pick()` strips anything it doesn't
+    // list, so omitting them silently dropped the secondary contact on submit.
+    emergencyContactName2: true,
+    emergencyContactPhone2: true,
   }),
 
 
@@ -106,27 +114,27 @@ function formatEnumLabel(value: string): string {
     .join(' ')
 }
 
-const languageItems: InputMenuItem[] = Object.values(Language).map(language => ({
+export const languageItems: InputMenuItem[] = Object.values(Language).map(language => ({
   id: language,
   label: formatEnumLabel(language),
 }))
 
-const genderItems: InputMenuItem[] = Object.values(Gender).map(gender => ({
+export const genderItems: InputMenuItem[] = Object.values(Gender).map(gender => ({
   id: gender,
   label: formatEnumLabel(gender),
 }))
 
-const ethinicityItems: InputMenuItem[] = Object.values(Ethinicity).map(e => ({
+export const ethinicityItems: InputMenuItem[] = Object.values(Ethinicity).map(e => ({
   id: e,
   label: formatEnumLabel(e),
 }))
 
-const availabilityItems: InputMenuItem[] = Object.values(Availability).map(a => ({
+export const availabilityItems: InputMenuItem[] = Object.values(Availability).map(a => ({
   id: a,
   label: formatEnumLabel(a),
 }))
 
-const volunteerAreaItems: InputMenuItem[] = [
+export const volunteerAreaItems: InputMenuItem[] = [
   { id: 'CLINIC_SUPPORT', label: 'Clinic Support (Volunteers will not be seeing clients)' },
   { id: 'MOBILE_CLINIC_OUTREACH', label: 'Mobile Clinic Outreach' },
   { id: 'EVENT_SUPPORT', label: 'Event Support' },
@@ -135,7 +143,7 @@ const volunteerAreaItems: InputMenuItem[] = [
   { id: 'OTHER', label: 'Other' },
 ]
 
-const certificationItems: InputMenuItem[] = [
+export const certificationItems: InputMenuItem[] = [
   { id: 'MEDICAL_CODING', label: 'Medical Coding' },
   { id: 'DOULA_CERTIFICATION', label: 'Doula Certification' },
   { id: 'CDL', label: 'CDL (Commercial Driver\'s License)' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -39,6 +39,22 @@ export default defineNuxtConfig({
       ],
     },
   },
+  nitro: {
+    externals: {
+      // web-push and its ASN.1 dependencies are CommonJS. Left external,
+      // Nitro's dev server loads them through Node's ESM loader and every
+      // server route dies at module-compile time. Bundling the whole tree
+      // lets Rollup apply CJS interop consistently.
+      inline: ['web-push', 'asn1.js', 'bn.js'],
+    },
+  },
+  runtimeConfig: {
+    public: {
+      // VAPID public key, needed client-side to create a push subscription.
+      // Safe to expose — the private key stays on the server (server/utils/push.ts).
+      vapidPublicKey: process.env.VAPID_PUBLIC_KEY ?? '',
+    },
+  },
   compatibilityDate: '2025-07-15',
   vite: {
     optimizeDeps: {
@@ -95,7 +111,13 @@ export default defineNuxtConfig({
     workbox: {
       navigateFallback: '/',
       globPatterns: ['**/*.{js,css,html,png,svg,ico}'],
+      // push-sw.js is imported into the service worker below, so it must not
+      // also be precached as a page asset.
+      globIgnores: ['**/push-sw.js'],
       navigateFallbackAllowlist: [/^\/(?!api)/],
+      // Adds the Web Push `push` / `notificationclick` handlers to the
+      // generated Workbox service worker. See public/push-sw.js.
+      importScripts: ['/push-sw.js'],
     },
     devOptions: {
       enabled: false,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "postinstall": "nuxt prepare",
-    "db:generate": "prisma generate"
+    "db:generate": "prisma generate",
+    "push:keys": "web-push generate-vapid-keys"
   },
   "dependencies": {
     "@internationalized/date": "^3.10.0",
@@ -28,6 +29,7 @@
     "vue": "^3.5.20",
     "vue-router": "^4.5.1",
     "vue3-carousel": "^0.16.0",
+    "web-push": "^3.6.7",
     "zod": "^4.1.12"
   },
   "devDependencies": {
@@ -37,6 +39,7 @@
     "@types/node": "^24.3.1",
     "@types/nodemailer": "^8.0.0",
     "@types/parse-path": "^7.1.0",
+    "@types/web-push": "^3.6.4",
     "@vite-pwa/nuxt": "^1.1.1",
     "dotenv": "^17.2.3",
     "eslint": "^9.34.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       vue3-carousel:
         specifier: ^0.16.0
         version: 0.16.0(vue@3.5.33(typescript@5.9.3))
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: ^4.1.12
         version: 4.3.6
@@ -72,6 +75,9 @@ importers:
       '@types/parse-path':
         specifier: ^7.1.0
         version: 7.1.0
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       '@vite-pwa/nuxt':
         specifier: ^1.1.1
         version: 1.1.1(magicast@0.5.2)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workbox-build@7.4.0)(workbox-window@7.4.0)
@@ -2749,6 +2755,9 @@ packages:
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@typescript-eslint/eslint-plugin@8.59.0':
     resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3162,6 +3171,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
@@ -3364,6 +3376,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  bn.js@4.12.5:
+    resolution: {integrity: sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -3389,6 +3404,9 @@ packages:
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -3803,6 +3821,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -4464,6 +4485,10 @@ packages:
   http-status-codes@2.3.0:
     resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -4775,6 +4800,12 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   kdbush@4.0.2:
     resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
 
@@ -5035,6 +5066,9 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -6755,6 +6789,11 @@ packages:
 
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -9777,6 +9816,10 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 24.12.2
+
   '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -10044,7 +10087,7 @@ snapshots:
       '@vue/shared': 3.5.33
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.10
+      postcss: 8.5.14
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.33':
@@ -10234,6 +10277,13 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.5
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   ast-kit@2.2.0:
     dependencies:
       '@babel/parser': 7.29.2
@@ -10392,6 +10442,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  bn.js@4.12.5: {}
+
   boolbase@1.0.0: {}
 
   brace-expansion@1.1.14:
@@ -10420,6 +10472,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-crc32@1.0.0: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -10826,6 +10880,10 @@ snapshots:
   earcut@3.0.2: {}
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -11653,6 +11711,8 @@ snapshots:
 
   http-status-codes@2.3.0: {}
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -11939,6 +11999,17 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   kdbush@4.0.2: {}
 
   keyv@4.5.4:
@@ -12177,6 +12248,8 @@ snapshots:
   mimic-fn@4.0.0: {}
 
   mimic-response@3.1.0: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -14287,6 +14360,16 @@ snapshots:
       typescript: 5.9.3
 
   w3c-keyname@2.2.8: {}
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   webidl-conversions@3.0.1: {}
 

--- a/prisma/migrations/20260806202004_settings_push_prefs_and_subscriptions/migration.sql
+++ b/prisma/migrations/20260806202004_settings_push_prefs_and_subscriptions/migration.sql
@@ -1,0 +1,39 @@
+-- CreateTable
+CREATE TABLE "push_subscriptions" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "p256dh" TEXT NOT NULL,
+    "auth" TEXT NOT NULL,
+    "userAgent" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "push_subscriptions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_users" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT,
+    "email" TEXT NOT NULL,
+    "phone" TEXT,
+    "emailVerified" BOOLEAN NOT NULL DEFAULT false,
+    "imageURL" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "pushEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "pushScope" TEXT NOT NULL DEFAULT 'BOTH'
+);
+INSERT INTO "new_users" ("createdAt", "email", "emailVerified", "id", "imageURL", "name", "phone", "updatedAt") SELECT "createdAt", "email", "emailVerified", "id", "imageURL", "name", "phone", "updatedAt" FROM "users";
+DROP TABLE "users";
+ALTER TABLE "new_users" RENAME TO "users";
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "push_subscriptions_endpoint_key" ON "push_subscriptions"("endpoint");
+
+-- CreateIndex
+CREATE INDEX "push_subscriptions_userId_idx" ON "push_subscriptions"("userId");

--- a/prisma/schema/notification.prisma
+++ b/prisma/schema/notification.prisma
@@ -7,3 +7,28 @@ model Notification {
 
   @@map("notifications")
 }
+
+/// Which kinds of event notification a user wants pushed to their devices.
+enum PushScope {
+  GENERAL
+  VOLUNTEER
+  BOTH
+}
+
+/// One Web Push subscription, i.e. one browser/installed-PWA on one device.
+/// A user can have several (phone + desktop), so pushes fan out across rows.
+/// `endpoint` is the push service URL and is globally unique, which lets an
+/// existing subscription be upserted when a device re-subscribes.
+model PushSubscription {
+  id        String   @id @default(uuid())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  endpoint  String   @unique
+  p256dh    String
+  auth      String
+  userAgent String?
+  createdAt DateTime @default(now())
+
+  @@index([userId])
+  @@map("push_subscriptions")
+}

--- a/prisma/schema/user.prisma
+++ b/prisma/schema/user.prisma
@@ -14,6 +14,11 @@ model User {
   accounts      Account[]
   volunteer     Volunteer?
 
+  // Push notification preferences, managed from /settings.
+  pushEnabled       Boolean          @default(false)
+  pushScope         PushScope        @default(BOTH)
+  pushSubscriptions PushSubscription[]
+
   @@map("users")
 }
 

--- a/public/push-sw.js
+++ b/public/push-sw.js
@@ -1,0 +1,57 @@
+/* eslint-disable no-undef */
+/**
+ * Push handlers for the PWA service worker.
+ *
+ * Pulled into the generated Workbox service worker via `workbox.importScripts`
+ * in nuxt.config.ts. It lives in public/ as plain JS (not app/ TypeScript)
+ * because it runs in the service worker scope, which has no bundler pass and
+ * no access to app code.
+ *
+ * Payloads come from server/utils/push.ts and look like:
+ *   { title, body, url?, tag? }
+ */
+
+self.addEventListener('push', (event) => {
+  let payload = {}
+  try {
+    payload = event.data ? event.data.json() : {}
+  }
+  catch {
+    // A push with a non-JSON body still deserves to surface rather than be
+    // dropped silently — browsers may show a generic "site updated in the
+    // background" notice otherwise.
+    payload = { title: 'Abide Connect', body: event.data ? event.data.text() : '' }
+  }
+
+  const title = payload.title || 'Abide Connect'
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body: payload.body || '',
+      icon: '/icon-192.png',
+      badge: '/icon-192.png',
+      tag: payload.tag || undefined,
+      data: { url: payload.url || '/' },
+    }),
+  )
+})
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+
+  const url = (event.notification.data && event.notification.data.url) || '/'
+
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+      // Reuse an already-open window where possible so tapping a notification
+      // doesn't stack up duplicate PWA windows.
+      for (const client of clientList) {
+        if ('focus' in client) {
+          if ('navigate' in client) client.navigate(url)
+          return client.focus()
+        }
+      }
+      if (self.clients.openWindow) return self.clients.openWindow(url)
+    }),
+  )
+})

--- a/server/api/push/subscribe.post.ts
+++ b/server/api/push/subscribe.post.ts
@@ -1,0 +1,38 @@
+import { auth } from '#server/utils/auth'
+import prisma from '#server/utils/prisma'
+
+/**
+ * Registers the caller's browser/installed-PWA as a push target.
+ *
+ * Keyed on the push service `endpoint`, so re-subscribing the same device
+ * updates the existing row rather than creating duplicates. Subscribing does
+ * not by itself turn notifications on — that's the `pushEnabled` flag on the
+ * user, set from /settings.
+ */
+export default defineEventHandler(async (event) => {
+  const session = await auth.api.getSession({ headers: event.headers })
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Not signed in' })
+  }
+
+  const body = await readBody(event)
+  const endpoint = body?.endpoint
+  const p256dh = body?.keys?.p256dh
+  const authKey = body?.keys?.auth
+
+  if (typeof endpoint !== 'string' || typeof p256dh !== 'string' || typeof authKey !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid push subscription' })
+  }
+
+  const userAgent = getRequestHeader(event, 'user-agent')?.slice(0, 255) ?? null
+
+  await prisma.pushSubscription.upsert({
+    where: { endpoint },
+    // An endpoint can be handed to a different account if two people share a
+    // device, so reassign userId on conflict rather than leaving it stale.
+    update: { userId: session.user.id, p256dh, auth: authKey, userAgent },
+    create: { userId: session.user.id, endpoint, p256dh, auth: authKey, userAgent },
+  })
+
+  return { success: true }
+})

--- a/server/api/push/test.post.ts
+++ b/server/api/push/test.post.ts
@@ -1,0 +1,30 @@
+import { auth } from '#server/utils/auth'
+import { pushConfigured, sendPushToUserDevices } from '#server/utils/push'
+
+/**
+ * Fires a test notification at the caller's own devices, so a volunteer can
+ * confirm push actually works on their phone before relying on it.
+ */
+export default defineEventHandler(async (event) => {
+  const session = await auth.api.getSession({ headers: event.headers })
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Not signed in' })
+  }
+
+  if (!pushConfigured) {
+    throw createError({ statusCode: 503, statusMessage: 'Push notifications are not configured on this server' })
+  }
+
+  const result = await sendPushToUserDevices(session.user.id, {
+    title: 'Abide Connect',
+    body: 'Push notifications are working on this device.',
+    url: '/settings',
+    tag: 'test-notification',
+  })
+
+  if (result.sent === 0) {
+    throw createError({ statusCode: 400, statusMessage: 'No active subscription for this device. Try turning notifications off and on again.' })
+  }
+
+  return result
+})

--- a/server/api/push/unsubscribe.post.ts
+++ b/server/api/push/unsubscribe.post.ts
@@ -1,0 +1,24 @@
+import { auth } from '#server/utils/auth'
+import prisma from '#server/utils/prisma'
+
+/**
+ * Drops a push subscription. Scoped to the caller's own rows so one user can't
+ * unsubscribe another's device by guessing an endpoint.
+ */
+export default defineEventHandler(async (event) => {
+  const session = await auth.api.getSession({ headers: event.headers })
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Not signed in' })
+  }
+
+  const { endpoint } = await readBody(event)
+  if (typeof endpoint !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: 'Missing endpoint' })
+  }
+
+  await prisma.pushSubscription.deleteMany({
+    where: { endpoint, userId: session.user.id },
+  })
+
+  return { success: true }
+})

--- a/server/api/user/me.delete.ts
+++ b/server/api/user/me.delete.ts
@@ -1,0 +1,58 @@
+import { auth } from '#server/utils/auth'
+import prisma from '#server/utils/prisma'
+
+/**
+ * Permanently deletes the signed-in user's account and everything hanging off
+ * it. Irreversible — the client is expected to confirm before calling.
+ *
+ * Most relations in the schema have no `onDelete: Cascade`, so dependants are
+ * removed explicitly, deepest first, inside a transaction. Session/Account
+ * (better-auth) and PushSubscription do cascade, but sessions are cleared
+ * up front anyway so the account can't keep being used mid-delete.
+ *
+ * Volunteer_Hour_Log rows go with the account. They're per-volunteer records
+ * rather than an aggregate Abide reports on, and leaving orphaned rows behind
+ * would break the volunteerId foreign key.
+ */
+export default defineEventHandler(async (event) => {
+  const session = await auth.api.getSession({ headers: event.headers })
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Not signed in' })
+  }
+
+  const userId = session.user.id
+
+  await prisma.$transaction(async (tx) => {
+    const volunteer = await tx.volunteer.findUnique({
+      where: { userId },
+      select: { id: true },
+    })
+
+    if (volunteer) {
+      const volunteerId = volunteer.id
+      await tx.volunteer_Language.deleteMany({ where: { volunteerId } })
+      await tx.volunteer_Availability.deleteMany({ where: { volunteerId } })
+      await tx.volunteer_VolunteerArea.deleteMany({ where: { volunteerId } })
+      await tx.volunteer_Certification.deleteMany({ where: { volunteerId } })
+      await tx.volunteer_Hour_Log.deleteMany({ where: { volunteerId } })
+      // RSVPs are keyed on userId, but an RSVP can also point at the volunteer
+      // record, so clear both angles before the volunteer row goes.
+      await tx.rSVP.deleteMany({ where: { volunteerId } })
+    }
+
+    await tx.rSVP.deleteMany({ where: { userId } })
+    await tx.user_Notification.deleteMany({ where: { userId } })
+    await tx.user_Role.deleteMany({ where: { userId } })
+    await tx.pushSubscription.deleteMany({ where: { userId } })
+    await tx.session.deleteMany({ where: { userId } })
+    await tx.account.deleteMany({ where: { userId } })
+
+    if (volunteer) {
+      await tx.volunteer.delete({ where: { id: volunteer.id } })
+    }
+
+    await tx.user.delete({ where: { id: userId } })
+  })
+
+  return { success: true }
+})

--- a/server/api/user/me.patch.ts
+++ b/server/api/user/me.patch.ts
@@ -1,0 +1,84 @@
+import { auth } from '#server/utils/auth'
+import prisma from '#server/utils/prisma'
+import { PushScope } from '#server/utils/generated/prisma/enums'
+
+/**
+ * Updates the signed-in user's own profile and notification preferences.
+ *
+ * Email is intentionally not editable here: it's the login identifier for both
+ * auth methods (Google OAuth subject match and email OTP delivery), so changing
+ * it would need a verification round-trip rather than a plain write. Any
+ * `email` key in the body is ignored rather than rejected, so a client sending
+ * back a whole user object doesn't fail.
+ */
+export default defineEventHandler(async (event) => {
+  const session = await auth.api.getSession({ headers: event.headers })
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Not signed in' })
+  }
+
+  const body = await readBody(event)
+  const data: {
+    name?: string | null
+    phone?: string | null
+    pushEnabled?: boolean
+    pushScope?: PushScope
+  } = {}
+
+  if ('name' in body) {
+    const name = typeof body.name === 'string' ? body.name.trim() : ''
+    if (name.length === 0) {
+      throw createError({ statusCode: 400, statusMessage: 'Name cannot be empty' })
+    }
+    if (name.length > 100) {
+      throw createError({ statusCode: 400, statusMessage: 'Name must be 100 characters or fewer' })
+    }
+    data.name = name
+  }
+
+  if ('phone' in body) {
+    const phone = typeof body.phone === 'string' ? body.phone.trim() : ''
+    // Optional field — an empty string clears it rather than storing "".
+    if (phone.length === 0) {
+      data.phone = null
+    }
+    else if (!/^[+\d][\d\s\-().]{6,19}$/.test(phone)) {
+      throw createError({ statusCode: 400, statusMessage: 'Please enter a valid phone number' })
+    }
+    else {
+      data.phone = phone
+    }
+  }
+
+  if ('pushEnabled' in body) {
+    if (typeof body.pushEnabled !== 'boolean') {
+      throw createError({ statusCode: 400, statusMessage: 'pushEnabled must be a boolean' })
+    }
+    data.pushEnabled = body.pushEnabled
+  }
+
+  if ('pushScope' in body) {
+    if (!Object.values(PushScope).includes(body.pushScope)) {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid notification scope' })
+    }
+    data.pushScope = body.pushScope as PushScope
+  }
+
+  if (Object.keys(data).length === 0) {
+    throw createError({ statusCode: 400, statusMessage: 'No updatable fields provided' })
+  }
+
+  return prisma.user.update({
+    where: { id: session.user.id },
+    data,
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      phone: true,
+      imageURL: true,
+      pushEnabled: true,
+      pushScope: true,
+    },
+  })
+})

--- a/server/api/volunteer/application.post.ts
+++ b/server/api/volunteer/application.post.ts
@@ -15,6 +15,9 @@ export default defineEventHandler(async (event) => {
       gender,
       ethinicity,
       languages,
+      // The form field is `availability` (singular); accept the plural too so
+      // any older client payload still applies.
+      availability,
       availabilities,
       volunteerAreas,
       certifications,
@@ -46,7 +49,7 @@ export default defineEventHandler(async (event) => {
             create: ((languages ?? []) as Language[]).map(language => ({ language })),
           },
           availabilities: {
-            create: ((availabilities ?? []) as Availability[]).map(availability => ({ availability })),
+            create: ((availability ?? availabilities ?? []) as Availability[]).map(a => ({ availability: a })),
           },
           volunteerAreas: {
             create: ((volunteerAreas ?? []) as VolunteerArea[]).map(volunteerArea => ({ volunteerArea })),

--- a/server/api/volunteer/me.get.ts
+++ b/server/api/volunteer/me.get.ts
@@ -1,16 +1,46 @@
+import { auth } from '#server/utils/auth'
+import prisma from '#server/utils/prisma'
 
+/**
+ * The signed-in user's volunteer record, with the join-table selections
+ * flattened into plain enum arrays so the settings form can bind to them
+ * directly. Returns null when the user hasn't applied to volunteer.
+ */
 export default defineEventHandler(async (event) => {
-  const session = await auth.api.getSession({ headers: event.headers });
-  event.context.session = session;
+  const session = await auth.api.getSession({ headers: event.headers })
+  event.context.session = session
 
-
-  if (!session?.session) {
-    return;
+  if (!session?.user) {
+    return null
   }
 
   const volunteer = await prisma.volunteer.findUnique({
-    where: { userId: session?.user.id },
+    where: { userId: session.user.id },
+    include: {
+      languages: true,
+      availabilities: true,
+      volunteerAreas: true,
+      certifications: true,
+    },
   })
- 
-  return volunteer
+
+  if (!volunteer) return null
+
+  return {
+    id: volunteer.id,
+    approvalStatus: volunteer.approvalStatus,
+    gender: volunteer.gender,
+    ethinicity: volunteer.ethinicity,
+    // `availability` (singular) matches the application form's field name.
+    languages: volunteer.languages.map(l => l.language),
+    availability: volunteer.availabilities.map(a => a.availability),
+    volunteerAreas: volunteer.volunteerAreas.map(v => v.volunteerArea),
+    certifications: volunteer.certifications.map(c => c.certification),
+    otherVolunteerAreaDescription: volunteer.otherVolunteerAreaDescription,
+    otherCertificationDescription: volunteer.otherCertificationDescription,
+    emergencyContactName1: volunteer.emergencyContactName1,
+    emergencyContactPhone1: volunteer.emergencyContactPhone1,
+    emergencyContactName2: volunteer.emergencyContactName2,
+    emergencyContactPhone2: volunteer.emergencyContactPhone2,
+  }
 })

--- a/server/api/volunteer/me.patch.ts
+++ b/server/api/volunteer/me.patch.ts
@@ -1,0 +1,146 @@
+import { auth } from '#server/utils/auth'
+import prisma from '#server/utils/prisma'
+import { Gender, Ethinicity, Language, Availability, VolunteerArea, Certification } from '#server/utils/generated/prisma/enums'
+
+/**
+ * Lets a volunteer revise their own application from /settings.
+ *
+ * Two deliberate limits:
+ *  - The step-3 legal acknowledgements (code of conduct, NDA, handbook,
+ *    background check consent, …) are not editable. They record what was agreed
+ *    to at submission time, so they're captured once by the application flow
+ *    and never rewritten here.
+ *  - `approvalStatus` is untouched, so fixing a phone number doesn't cost an
+ *    approved volunteer their access. Only admins move that, via
+ *    /api/volunteer/[id]/approval.
+ *
+ * The enum join tables have no updatable payload beyond their own key, so each
+ * selection set is replaced wholesale (delete + recreate) inside the
+ * transaction rather than diffed.
+ */
+
+/** Keeps only values that are real members of the given Prisma enum. */
+function sanitizeEnumList<T extends Record<string, string>>(
+  value: unknown,
+  enumObject: T,
+  field: string,
+): T[keyof T][] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value)) {
+    throw createError({ statusCode: 400, statusMessage: `${field} must be a list` })
+  }
+
+  const allowed = Object.values(enumObject) as string[]
+  const invalid = value.filter(v => typeof v !== 'string' || !allowed.includes(v))
+  if (invalid.length > 0) {
+    throw createError({ statusCode: 400, statusMessage: `Invalid ${field}: ${invalid.join(', ')}` })
+  }
+
+  // Dedupe — the join tables are keyed on [volunteerId, value], so a repeated
+  // selection would blow up the createMany.
+  return [...new Set(value)] as T[keyof T][]
+}
+
+function sanitizeEnum<T extends Record<string, string>>(
+  value: unknown,
+  enumObject: T,
+  field: string,
+): T[keyof T] | undefined {
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== 'string' || !(Object.values(enumObject) as string[]).includes(value)) {
+    throw createError({ statusCode: 400, statusMessage: `Invalid ${field}` })
+  }
+  return value as T[keyof T]
+}
+
+/** Trims a free-text field, mapping blank to null so we don't store "". */
+function sanitizeText(value: unknown, field: string, maxLength = 500): string | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null) return null
+  if (typeof value !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: `${field} must be text` })
+  }
+  const trimmed = value.trim()
+  if (trimmed.length > maxLength) {
+    throw createError({ statusCode: 400, statusMessage: `${field} must be ${maxLength} characters or fewer` })
+  }
+  return trimmed.length === 0 ? null : trimmed
+}
+
+export default defineEventHandler(async (event) => {
+  const session = await auth.api.getSession({ headers: event.headers })
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Not signed in' })
+  }
+
+  const volunteer = await prisma.volunteer.findUnique({
+    where: { userId: session.user.id },
+    select: { id: true },
+  })
+  if (!volunteer) {
+    throw createError({ statusCode: 404, statusMessage: 'No volunteer application found for this account' })
+  }
+
+  const body = await readBody(event)
+
+  const languages = sanitizeEnumList(body.languages, Language, 'languages')
+  const availability = sanitizeEnumList(body.availability, Availability, 'availability')
+  const volunteerAreas = sanitizeEnumList(body.volunteerAreas, VolunteerArea, 'volunteerAreas')
+  const certifications = sanitizeEnumList(body.certifications, Certification, 'certifications')
+
+  const scalarData = {
+    gender: sanitizeEnum(body.gender, Gender, 'gender'),
+    ethinicity: sanitizeEnum(body.ethinicity, Ethinicity, 'ethinicity'),
+    otherVolunteerAreaDescription: sanitizeText(body.otherVolunteerAreaDescription, 'Other volunteer area description'),
+    otherCertificationDescription: sanitizeText(body.otherCertificationDescription, 'Other certification description'),
+    emergencyContactName1: sanitizeText(body.emergencyContactName1, 'Primary emergency contact name', 100),
+    emergencyContactPhone1: sanitizeText(body.emergencyContactPhone1, 'Primary emergency contact phone', 30),
+    emergencyContactName2: sanitizeText(body.emergencyContactName2, 'Secondary emergency contact name', 100),
+    emergencyContactPhone2: sanitizeText(body.emergencyContactPhone2, 'Secondary emergency contact phone', 30),
+  }
+
+  // The primary emergency contact is required on the application, so don't let
+  // an edit blank it out.
+  if ('emergencyContactName1' in body && !scalarData.emergencyContactName1) {
+    throw createError({ statusCode: 400, statusMessage: 'A primary emergency contact name is required' })
+  }
+  if ('emergencyContactPhone1' in body && !scalarData.emergencyContactPhone1) {
+    throw createError({ statusCode: 400, statusMessage: 'A primary emergency contact phone number is required' })
+  }
+
+  const volunteerId = volunteer.id
+
+  await prisma.$transaction(async (tx) => {
+    await tx.volunteer.update({ where: { id: volunteerId }, data: scalarData })
+
+    if (languages) {
+      await tx.volunteer_Language.deleteMany({ where: { volunteerId } })
+      await tx.volunteer_Language.createMany({
+        data: languages.map(language => ({ volunteerId, language })),
+      })
+    }
+
+    if (availability) {
+      await tx.volunteer_Availability.deleteMany({ where: { volunteerId } })
+      await tx.volunteer_Availability.createMany({
+        data: availability.map(a => ({ volunteerId, availability: a })),
+      })
+    }
+
+    if (volunteerAreas) {
+      await tx.volunteer_VolunteerArea.deleteMany({ where: { volunteerId } })
+      await tx.volunteer_VolunteerArea.createMany({
+        data: volunteerAreas.map(volunteerArea => ({ volunteerId, volunteerArea })),
+      })
+    }
+
+    if (certifications) {
+      await tx.volunteer_Certification.deleteMany({ where: { volunteerId } })
+      await tx.volunteer_Certification.createMany({
+        data: certifications.map(certification => ({ volunteerId, certification })),
+      })
+    }
+  })
+
+  return { success: true }
+})

--- a/server/utils/push.ts
+++ b/server/utils/push.ts
@@ -1,0 +1,115 @@
+import webpush from 'web-push'
+import prisma from './prisma'
+import type { PushScope, PushSubscription } from './generated/prisma/client'
+
+/**
+ * Web Push (VAPID) delivery.
+ *
+ * Deliberately browser-only: an installed PWA subscribes through its own
+ * service worker and the browser's push service handles the device hand-off,
+ * so there is no APNs certificate or FCM project to maintain. On iOS this
+ * requires the app to be added to the home screen (Safari 16.4+); in a plain
+ * Safari tab `PushManager` isn't exposed and subscription is never offered.
+ */
+
+const publicKey = process.env.VAPID_PUBLIC_KEY
+const privateKey = process.env.VAPID_PRIVATE_KEY
+const subject = process.env.VAPID_SUBJECT ?? 'mailto:info@abidewomen.org'
+
+/** True when VAPID keys are configured, i.e. push can actually be sent. */
+export const pushConfigured = Boolean(publicKey && privateKey)
+
+if (pushConfigured) {
+  webpush.setVapidDetails(subject, publicKey!, privateKey!)
+}
+else {
+  console.warn('[push] VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY not set — push notifications are disabled. Generate a pair with `pnpm push:keys`.')
+}
+
+export type PushPayload = {
+  title: string
+  body: string
+  /** Path the notification opens when tapped, e.g. `/events/123`. */
+  url?: string
+  tag?: string
+}
+
+export type PushResult = { sent: number, failed: number }
+
+/**
+ * Delivers to a concrete set of subscriptions and prunes any the push service
+ * reports as gone (404/410 — permission revoked, app uninstalled, endpoint
+ * rotated).
+ *
+ * Best-effort: never throws, so a failing push can't roll back the DB write
+ * that triggered it.
+ */
+async function deliver(subscriptions: PushSubscription[], payload: PushPayload): Promise<PushResult> {
+  if (!pushConfigured || subscriptions.length === 0) return { sent: 0, failed: 0 }
+
+  const body = JSON.stringify(payload)
+  const expired: string[] = []
+  let sent = 0
+  let failed = 0
+
+  await Promise.all(subscriptions.map(async (sub) => {
+    try {
+      await webpush.sendNotification(
+        { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+        body,
+      )
+      sent++
+    }
+    catch (error: unknown) {
+      failed++
+      const statusCode = (error as { statusCode?: number }).statusCode
+      if (statusCode === 404 || statusCode === 410) {
+        expired.push(sub.id)
+      }
+      else {
+        console.error('[push] send failed for subscription', sub.id, error)
+      }
+    }
+  }))
+
+  if (expired.length > 0) {
+    await prisma.pushSubscription.deleteMany({ where: { id: { in: expired } } })
+  }
+
+  return { sent, failed }
+}
+
+/**
+ * Sends to every device of the given users, skipping users who have push
+ * switched off or whose chosen scope doesn't cover this kind of notification.
+ * This is the entry point feature code should use.
+ */
+export async function sendPushToUsers(
+  userIds: string[],
+  kind: 'GENERAL' | 'VOLUNTEER',
+  payload: PushPayload,
+): Promise<PushResult> {
+  if (!pushConfigured || userIds.length === 0) return { sent: 0, failed: 0 }
+
+  // BOTH opts into everything; otherwise the scope must match the kind.
+  const scopes: PushScope[] = [kind, 'BOTH']
+
+  const subscriptions = await prisma.pushSubscription.findMany({
+    where: {
+      userId: { in: userIds },
+      user: { pushEnabled: true, pushScope: { in: scopes } },
+    },
+  })
+
+  return deliver(subscriptions, payload)
+}
+
+/**
+ * Sends to one user's devices ignoring their scope preference — for the
+ * "send a test notification" button in /settings, where the point is to verify
+ * the device is wired up correctly.
+ */
+export async function sendPushToUserDevices(userId: string, payload: PushPayload): Promise<PushResult> {
+  const subscriptions = await prisma.pushSubscription.findMany({ where: { userId } })
+  return deliver(subscriptions, payload)
+}


### PR DESCRIPTION
Replaces the settings page's placeholder local state with settings that actually persist.

- Profile: edit name and phone. Email is deliberately not editable, since it's the login identifier for both Google OAuth and email OTP.
- Theme: light, dark, or match system, bound to colorMode.preference so "match system" survives a reload.
- Push notifications: enable/disable, choose scope (general, volunteer or both), and send a test notification to verify a device.
- Account deletion behind a confirmation modal, removing the user and all dependent rows in one transaction.
- Volunteer application editing, shown only to users who hold the volunteer role and have an application on file. The step-3 legal acknowledgements stay locked, and edits don't disturb approvalStatus.

Push is plain Web Push (VAPID) through the PWA's own service worker, so there's no APNs certificate or FCM project involved. sendPushToUsers() in server/utils/push.ts is the entry point for feature code; it honours each user's preferences, fans out across their devices and prunes expired subscriptions. web-push and its ASN.1 dependencies must stay inlined in the Nitro config — left external, dev-mode module loading breaks every server route.

/settings previously had no auth guard at all, so it now opts into the 'auth' middleware before exposing personal details and account deletion.

Also fixes three pre-existing bugs found along the way:

- events.calendarEventId was absent from any database built by replaying migrations, because 20260722174559 rebuilds the events table without carrying the column that 20260714191036 adds, and migrations replay in filename order. This most likely breaks Google Calendar sync on deployed environments.
- Volunteer availability was never saved: the application form sends `availability` but the handler read `availabilities`.
- The secondary emergency contact was silently dropped, as the step-2 Zod schema's .pick() omitted both fields and validation stripped them.